### PR TITLE
Avoid mutating entity data

### DIFF
--- a/rich-content-editor/src/Utils/simplePubsub.js
+++ b/rich-content-editor/src/Utils/simplePubsub.js
@@ -18,7 +18,7 @@ const simplePubsub = initialState => {
 
   const update = (key, newData) => {
     const data = get(key);
-    const newItem = merge(data, newData);
+    const newItem = merge({}, data, newData);
     set(key, newItem);
   };
 


### PR DESCRIPTION
When `pubsub.update('componentData', data);` is called it mutates entity data and causes autosave related problems in blog.