### PR TITLE
Fix input ids

### DIFF
--- a/rich-content-editor/src/Components/InputWithLabel.js
+++ b/rich-content-editor/src/Components/InputWithLabel.js
@@ -12,7 +12,7 @@ class InputWithLabel extends Component {
   }
   render() {
     const { styles } = this;
-    const { label, placeholder, value, onChange, isTextArea, dataHook } = this.props;
+    const { id, label, placeholder, value, onChange, isTextArea, dataHook } = this.props;
     const inputClassName = classNames(styles.inputWithLabel_input,
       {
         [styles.inputWithLabel_textArea]: isTextArea
@@ -20,17 +20,17 @@ class InputWithLabel extends Component {
     );
     return (
       <div>
-        {label ? <label className={this.styles.inputWithLabel_label} htmlFor={`${label}_input`}>{label}</label> : null}
+        {label ? <label className={this.styles.inputWithLabel_label} htmlFor={id}>{label}</label> : null}
         {isTextArea ? <textarea
           className={inputClassName}
           placeholder={placeholder}
-          id={label ? `${label}_input` : ''}
+          id={id}
           value={value}
           data-hook={dataHook} onChange={onChange}
         /> : <input
           className={styles.inputWithLabel_input}
           placeholder={placeholder}
-          id={label ? `${label}_input` : ''}
+          id={id}
           value={value}
           data-hook={dataHook} onChange={onChange}
         />}
@@ -39,6 +39,7 @@ class InputWithLabel extends Component {
   }
 }
 InputWithLabel.propTypes = {
+  id: PropTypes.string,
   label: PropTypes.string,
   placeholder: PropTypes.string,
   theme: PropTypes.object.isRequired,

--- a/rich-content-editor/src/Components/InputWithLabel.js
+++ b/rich-content-editor/src/Components/InputWithLabel.js
@@ -39,7 +39,7 @@ class InputWithLabel extends Component {
   }
 }
 InputWithLabel.propTypes = {
-  id: PropTypes.string,
+  id: PropTypes.string.isRequired,
   label: PropTypes.string,
   placeholder: PropTypes.string,
   theme: PropTypes.object.isRequired,

--- a/rich-content-editor/src/Plugins/wix-draft-plugin-gallery/components/gallery-controls/gallery-image-settings.js
+++ b/rich-content-editor/src/Plugins/wix-draft-plugin-gallery/components/gallery-controls/gallery-image-settings.js
@@ -150,6 +150,7 @@ class ImageSettings extends Component {
             <SettingsSection theme={theme} className={styles.galleryImageSettings_section}>
               <InputWithLabel
                 theme={theme}
+                id="galleryImageTitleInput"
                 label={titleLabel}
                 placeholder={titleInputPlaceholder}
                 value={selectedImage.metadata.title || ''}

--- a/rich-content-editor/src/Plugins/wix-draft-plugin-image/toolbar/image-settings.js
+++ b/rich-content-editor/src/Plugins/wix-draft-plugin-image/toolbar/image-settings.js
@@ -138,6 +138,7 @@ class ImageSettings extends Component {
           <SettingsSection theme={theme} className={this.styles.imageSettingsSection}>
             <InputWithLabel
               theme={theme}
+              id="imageSettingsCaptionInput"
               label={captionLabel}
               placeholder={captionInputPlaceholder}
               value={metadata.caption || ''}
@@ -148,6 +149,7 @@ class ImageSettings extends Component {
           <SettingsSection theme={theme} className={this.styles.imageSettingsSection}>
             <InputWithLabel
               theme={theme}
+              id="imageSettingsAltInput"
               label={altLabel}
               placeholder={altInputPlaceholder}
               value={metadata.alt || ''}


### PR DESCRIPTION
Currently label is used as input id so input ids contain white spaces which makes them invalid. 
Also wasn't sure what naming convention to use.
