### PR TITLE
Fix for DeviantArt build

### DIFF
--- a/packages/editor/src/RichContentEditor/Toolbars/StaticToolbar/createMobileToolbar.jsx
+++ b/packages/editor/src/RichContentEditor/Toolbars/StaticToolbar/createMobileToolbar.jsx
@@ -9,6 +9,20 @@ import toolbarStyles from '~/Styles/mobile-toolbar.scss';
 import buttonStyles from '~/Styles/mobile-toolbar-button.scss';
 import separatorStyles from '~/Styles/mobile-toolbar-separator.scss';
 
+const createMobileToolbar = ({ buttons, helpers, pubsub, getEditorState, setEditorState, anchorTarget, relValue, theme, t }) => {
+  const mobileTheme = getMobileTheme(theme);
+  return createStaticToolbar({
+    helpers,
+    t,
+    name: 'MobileToolbar',
+    theme: mobileTheme,
+    structure: getMobileButtons({ buttons, helpers, pubsub, getEditorState, setEditorState, mobileTheme, t }),
+    anchorTarget,
+    relValue,
+    isMobile: true
+  });
+};
+
 const getMobileTheme = theme => {
   const {
     toolbarStyles: toolbarTheme,
@@ -111,16 +125,4 @@ const getMobileButtons = ({ buttons, helpers, pubsub, getEditorState, setEditorS
   return structure;
 };
 
-export default ({ buttons, helpers, pubsub, getEditorState, setEditorState, anchorTarget, relValue, theme, t }) => {
-  const mobileTheme = getMobileTheme(theme);
-  return createStaticToolbar({
-    helpers,
-    t,
-    name: 'MobileToolbar',
-    theme: mobileTheme,
-    structure: getMobileButtons({ buttons, helpers, pubsub, getEditorState, setEditorState, mobileTheme, t }),
-    anchorTarget,
-    relValue,
-    isMobile: true
-  });
-};
+export default createMobileToolbar;


### PR DESCRIPTION
Ok this is a total heisenbug, it seems to be something in the yoshi build stack that does this, but I have little control to really dig into it.

Therefore I went for minimal changes to get the build to work, I think I have tried every combination of this file today :)

The basic fix it to change the code enough to trigger the compiler to compile the file differently, which fixes the reference error.

This change just moves the main exported block to the top and exports the default at the bottom.

Another one that works is to add:

```
if (!toolbarTheme) {
  console.warn('Failed to get mobile toolbar theme', theme);
}
```

I decided against adding the console log just because I didn't want to add code if I could avoid it. Hopefully this will fix it and wont resurface later, though its hard to tell with a bug like this.

