### PR TITLE
add ability to exclude plugin button from side/footer toolbars

### DIFF
--- a/packages/common/src/Base/createBasePlugin.jsx
+++ b/packages/common/src/Base/createBasePlugin.jsx
@@ -79,9 +79,10 @@ const createBasePlugin = (config = {}, underlyingPlugin) => {
     t,
     name: config.toolbar.name,
   });
-  const InsertPluginButtons = settings.showInsertButtons && config.toolbar && config.toolbar.InsertButtons.map(button => (
-    createInsertPluginButton({ blockType: config.type, button, helpers, pubsub, t })
-  ));
+  const InsertPluginButtons = settings.showInsertButtons && config.toolbar && config.toolbar.InsertButtons.map(button => ({
+    originalConfig: button,
+    component: createInsertPluginButton({ blockType: config.type, button, helpers, pubsub, t })
+  }));
   const PluginComponent = config.component && config.decorator ? config.decorator(config.component) : config.component;
 
   const CompWithBase = PluginComponent && createBaseComponent(

--- a/packages/editor/src/RichContentEditor/Toolbars/createEditorToolbars.js
+++ b/packages/editor/src/RichContentEditor/Toolbars/createEditorToolbars.js
@@ -22,16 +22,22 @@ const createEditorToolbars = config => {
     refId
   } = config;
   const { pluginButtons, textButtons } = buttons;
+  const sideToolbarPluginButtons = pluginButtons && pluginButtons
+    .filter(({ originalConfig }) => originalConfig.addToSideToolbar !== false)
+    .map(({ component }) => component);
+  const footerToolbarPluginButtons = pluginButtons && pluginButtons
+    .filter(({ originalConfig }) => originalConfig.addToFooterToolbar !== false)
+    .map(({ component }) => component);
   const pubsub = simplePubsub();
-  const shouldCreatePluginToolbars = pluginButtons && pluginButtons.length;
+  const shouldCreateSidePluginToolbar = pluginButtons && sideToolbarPluginButtons.length;
+  const shouldCreateFooterPluginToolbar = pluginButtons && footerToolbarPluginButtons.length;
   const shouldCreateTextToolbar = !isMobile || baseUtils.isiOS();
 
   const toolbars = {};
-
-  if (shouldCreatePluginToolbars) {
+  if (shouldCreateSidePluginToolbar) {
     toolbars.side = createSideToolbar({
       refId,
-      buttons: pluginButtons,
+      buttons: sideToolbarPluginButtons,
       offset: sideToolbarOffset,
       theme: { ...getToolbarTheme(theme, 'side'), ...theme },
       pubsub,
@@ -66,10 +72,10 @@ const createEditorToolbars = config => {
   }
 
   if (!isMobile) {
-    if (shouldCreatePluginToolbars && !hideFooterToolbar) {
+    if (shouldCreateFooterPluginToolbar && !hideFooterToolbar) {
       toolbars.footer = createFooterToolbar({
         refId,
-        buttons: pluginButtons,
+        buttons: footerToolbarPluginButtons,
         theme: { ...getToolbarTheme(theme, 'footer'), ...theme },
       });
     }


### PR DESCRIPTION
In configuration of InsertButtons, you can now exclude button from being added to `SideToolbar` or `FooterToolbar` by adding properties `addToFooterToolbar` `addToSideToolbar`, by default Buttons are added to both locations.

```
{
      addToSideToolbar: false,
      name: 'Emoji',
      tooltipText: t(tooltipTextKey),
      ButtonElement: InsertToolbarButton,
      helpers,
      t
}
```

**This is needed for emoji plugin**, because it doesn't make sense for it to be in a side toolbar.