### PR TITLE
UI Settings: allow to customize link option UI behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 #### :boom: Breaking Change
 * `code-block`:
   * `config.codeBlock.position` property is obsolete; use `config.getToolbarSettings` to override plugin text button settings
+* `general`:
+  * `config` plugin-specific section keys are standardized -- now the plugin types should be used as keys. Check [example](https://github.com/wix-incubator/rich-content/blob/develop/examples/editor/src/App.jsx) for reference
 
 #### :rocket: New Feature
 * `general`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
 > - :book:       [Documentation]
 
 ## [Unreleased]
+#### :boom: Breaking Change
+* `code-block`:
+  * `config.codeBlock.position` property is obsolete; use `config.getToolbarSettings` to override plugin text button settings
+
+#### :rocket: New Feature
+* `general`:
+  * RCE `config.uiSettings` API allows to customize the link option UI (e.g. 'Open link in a new tab', 'Add a nofollow tag'). Check [documentation](https://github.com/wix-incubator/rich-content/blob/develop/docs/UiSettings.md) for more details
+
+#### :bug: Bug Fix
+* `common`
+  * `Tooltip` performance: `rebuild` is called only if `shouldRebuildOnUpdate` returns true
+
+#### #### :book: Documentation
+* [UI Settings](https://github.com/wix-incubator/rich-content/blob/develop/docs/UiSettings.md) added
+
+<br/>
 
 ## 1.4.0 (Aug 22, 2018)
 
@@ -48,7 +64,7 @@
 
 #### :bug: Bug Fix
 * `general`
-  * Theme supports empty css classes 
+  * Theme supports empty css classes
 * `editor`
   * Firefox text editing
   * Close alignment dropdown when clicke d outside

--- a/docs/ToolbarCustomization.md
+++ b/docs/ToolbarCustomization.md
@@ -77,7 +77,7 @@ All the toolbar types are exposed by the `TOOLBARS` const found in [`consts.js`]
 `getTextPluginButtons`: defines a map of inline buttons added by plugins. The keys are derived from the `PluginTextButtonMappers` -- see the `link-plugin`'s [`createLinkToolbar`](https://github.com/wix-incubator/rich-content/blob/develop/packages/plugin-link/src/toolbar/createLinkToolbar.js) for reference
 
 ## References and examples
-The [`default-toolbar-settings.js`](https://github.com/wix-incubator/rich-content/blob/develop/packages/editor/src/RichContentEditor/Toolbars/default-toolbar-settings.js) contains the default toolbar settings, and the `getToolbarSettings` code example could be found in [`App.jsx`](https://github.com/wix-incubator/rich-content/blob/develop/examples/editor/src/App.jsx) (commented by default).
+The [`default-toolbar-settings.js`](https://github.com/wix-incubator/rich-content/blob/develop/packages/editor/src/RichContentEditor/Toolbars/default-toolbar-settings.js) contains the default toolbar settings, and the `getToolbarSettings` code example could be found in [`PluginsConfig.js`](https://github.com/wix-incubator/rich-content/blob/develop/examples/editor/src/PluginsConfig.js) (commented by default).
 
 ## Notes
 The plugin toolbar customization is not available yet.

--- a/docs/UiSettings.md
+++ b/docs/UiSettings.md
@@ -1,0 +1,21 @@
+# Toolbar Customization
+
+## Motivation
+As it turns out, various `RichContentEditor` consumers have different customization needs. On other hand, it is important to keep the public API clean, while providing the desired customability. In order to meet these requirements, the `RichContentEditor` exposes `config` object prop.
+
+This document focuses on a specific `config` API `uiSettings` that is responsible for  UI customization.
+
+## `uiSettings` API
+### Structure
+The `uiSettings` object exposes the following properties:
+  * `blankTargetToggleVisibilityFn` : `anchorTarget => boolean`
+
+    This function determines the 'Open link in a new tab' link panel checkbox visiblity.
+
+    By default, its predicate is `anchorTarget !== '_blank'`
+
+  * `nofollowRelToggleVisibilityFn` : `relValue => boolean`
+
+    This function determines the 'Add a nofollow tag' link panel checkbox visiblity.
+
+    By default, its predicate is `relValue !== 'nofollow'`

--- a/docs/UiSettings.md
+++ b/docs/UiSettings.md
@@ -1,7 +1,7 @@
 # Toolbar Customization
 
 ## Motivation
-As it turns out, various `RichContentEditor` consumers have different customization needs. On other hand, it is important to keep the public API clean, while providing the desired customability. In order to meet these requirements, the `RichContentEditor` exposes `config` object prop.
+As it turns out, various `RichContentEditor` consumers have different customization needs. On the other hand, it is important to keep the public API clean, while providing the desired customability. In order to meet these requirements, the `RichContentEditor` exposes `config` object prop.
 
 This document focuses on a specific `config` API `uiSettings` that is responsible for  UI customization.
 

--- a/examples/editor/src/App.jsx
+++ b/examples/editor/src/App.jsx
@@ -35,7 +35,7 @@ const modalStyleDefaults = {
   },
 };
 
-const anchorTarget = '_blink';
+const anchorTarget = '_blank';
 const relValue = 'nofollow';
 
 const uiSettings = {

--- a/examples/editor/src/App.jsx
+++ b/examples/editor/src/App.jsx
@@ -39,7 +39,7 @@ const anchorTarget = '_blink';
 const relValue = 'nofollow';
 
 const uiSettings = {
-  blankTargetToggleVisibilityFn: () => false,
+  blankTargetToggleVisibilityFn: () => true,
   nofollowRelToggleVisibilityFn: () => true
 };
 

--- a/examples/editor/src/App.jsx
+++ b/examples/editor/src/App.jsx
@@ -4,6 +4,18 @@ import ReactModal from 'react-modal';
 import MobileDetect from 'mobile-detect';
 import { convertFromRaw, convertToRaw, EditorState } from '@wix/draft-js';
 import Plugins from './Plugins';
+
+import { CODE_BLOCK_TYPE } from 'wix-rich-content-plugin-code-block';
+import { DIVIDER_TYPE } from 'wix-rich-content-plugin-divider';
+import { EXTERNAL_EMOJI_TYPE } from 'wix-rich-content-plugin-emoji';
+import { GALLERY_TYPE } from 'wix-rich-content-plugin-gallery';
+import { HASHTAG_TYPE } from 'wix-rich-content-plugin-hashtag';
+import { HTML_TYPE } from 'wix-rich-content-plugin-html';
+import { IMAGE_TYPE } from 'wix-rich-content-plugin-image';
+import { LINK_TYPE } from 'wix-rich-content-plugin-link';
+import { VIDEO_TYPE } from 'wix-rich-content-plugin-video';
+import { EXTERNAL_MENTIONS_TYPE } from 'wix-rich-content-plugin-mentions';
+
 import ModalsMap from './ModalsMap';
 import { EditorState as RichEditorState, RichContentEditor, RichContentEditorModal } from 'wix-rich-content-editor';
 import { Button, normalizeInitialState, TOOLBARS } from 'wix-rich-content-common';
@@ -23,8 +35,13 @@ const modalStyleDefaults = {
   },
 };
 
-const anchorTarget = '_blank';
+const anchorTarget = '_blink';
 const relValue = 'nofollow';
+
+const uiSettings = {
+  blankTargetToggleVisibilityFn: () => false,
+  nofollowRelToggleVisibilityFn: () => true
+};
 
 class App extends Component {
   constructor(props) {
@@ -45,7 +62,7 @@ class App extends Component {
   initEditorProps() {
     this.plugins = Plugins;
     this.config = {
-      hashtag: {
+      [HASHTAG_TYPE]: {
         createHref: decoratedText =>
           `/search/posts?query=${encodeURIComponent('#')}${decoratedText}`,
         onClick: (event, text) => {
@@ -53,11 +70,11 @@ class App extends Component {
           console.log(`'${text}' hashtag clicked!`);
         },
       },
-      html: {
+      [HTML_TYPE]: {
         htmlIframeSrc: 'http://localhost:3000/static/html-plugin-embed.html',
         // showInsertButtons: false,
       },
-      mentions: {
+      [EXTERNAL_MENTIONS_TYPE]: {
         onMentionClick: mention => console.log({ mention }),
         getMentions: (searchQuery) => new Promise(resolve =>
           setTimeout(() => resolve([
@@ -68,6 +85,14 @@ class App extends Component {
             250),
         ),
       },
+      [LINK_TYPE]: { },
+      [CODE_BLOCK_TYPE]: { },
+      [DIVIDER_TYPE]: { },
+      [EXTERNAL_EMOJI_TYPE]: { },
+      [GALLERY_TYPE]: { },
+      [IMAGE_TYPE]: { },
+      [VIDEO_TYPE]: { },
+      uiSettings,
       // getToolbarSettings: ({ pluginButtons, textButtons }) => [
       //   {
       //     name: TOOLBARS.SIDE,

--- a/examples/editor/src/App.jsx
+++ b/examples/editor/src/App.jsx
@@ -4,18 +4,7 @@ import ReactModal from 'react-modal';
 import MobileDetect from 'mobile-detect';
 import { convertFromRaw, convertToRaw, EditorState } from '@wix/draft-js';
 import Plugins from './Plugins';
-
-import { CODE_BLOCK_TYPE } from 'wix-rich-content-plugin-code-block';
-import { DIVIDER_TYPE } from 'wix-rich-content-plugin-divider';
-import { EXTERNAL_EMOJI_TYPE } from 'wix-rich-content-plugin-emoji';
-import { GALLERY_TYPE } from 'wix-rich-content-plugin-gallery';
-import { HASHTAG_TYPE } from 'wix-rich-content-plugin-hashtag';
-import { HTML_TYPE } from 'wix-rich-content-plugin-html';
-import { IMAGE_TYPE } from 'wix-rich-content-plugin-image';
-import { LINK_TYPE } from 'wix-rich-content-plugin-link';
-import { VIDEO_TYPE } from 'wix-rich-content-plugin-video';
-import { EXTERNAL_MENTIONS_TYPE } from 'wix-rich-content-plugin-mentions';
-
+import PluginsConfig from './PluginsConfig';
 import ModalsMap from './ModalsMap';
 import { EditorState as RichEditorState, RichContentEditor, RichContentEditorModal } from 'wix-rich-content-editor';
 import { Button, normalizeInitialState, TOOLBARS } from 'wix-rich-content-common';
@@ -38,11 +27,6 @@ const modalStyleDefaults = {
 const anchorTarget = '_blank';
 const relValue = 'nofollow';
 
-const uiSettings = {
-  blankTargetToggleVisibilityFn: () => true,
-  nofollowRelToggleVisibilityFn: () => true
-};
-
 class App extends Component {
   constructor(props) {
     super(props);
@@ -61,108 +45,6 @@ class App extends Component {
 
   initEditorProps() {
     this.plugins = Plugins;
-    this.config = {
-      [HASHTAG_TYPE]: {
-        createHref: decoratedText =>
-          `/search/posts?query=${encodeURIComponent('#')}${decoratedText}`,
-        onClick: (event, text) => {
-          event.preventDefault();
-          console.log(`'${text}' hashtag clicked!`);
-        },
-      },
-      [HTML_TYPE]: {
-        htmlIframeSrc: 'http://localhost:3000/static/html-plugin-embed.html',
-        // showInsertButtons: false,
-      },
-      [EXTERNAL_MENTIONS_TYPE]: {
-        onMentionClick: mention => console.log({ mention }),
-        getMentions: (searchQuery) => new Promise(resolve =>
-          setTimeout(() => resolve([
-              { name: searchQuery, slug: searchQuery },
-              { name: 'Test One', slug: 'testone' },
-              { name: 'Test Two', slug: 'testwo', avatar: 'https://via.placeholder.com/100x100?text=Image=50' },
-            ]),
-            250),
-        ),
-      },
-      [LINK_TYPE]: { },
-      [CODE_BLOCK_TYPE]: { },
-      [DIVIDER_TYPE]: { },
-      [EXTERNAL_EMOJI_TYPE]: { },
-      [GALLERY_TYPE]: { },
-      [IMAGE_TYPE]: { },
-      [VIDEO_TYPE]: { },
-      uiSettings,
-      // getToolbarSettings: ({ pluginButtons, textButtons }) => [
-      //   {
-      //     name: TOOLBARS.SIDE,
-      //     getVisibilityFn: () => ({
-      //       desktop: () => true,
-      //       mobile: {
-      //         ios: () => true,
-      //         android: () => true,
-      //       }
-      //     }),
-      //   },
-      //   {
-      //     name: TOOLBARS.MOBILE,
-      //     shouldCreate: () => ({
-      //       desktop: false,
-      //       mobile: {
-      //         ios: false,
-      //         android: false,
-      //       }
-      //     }),
-      //   },
-      //   {
-      //     name: TOOLBARS.FOOTER,
-      //     getPositionOffset: () => ({
-      //       mobile: {
-      //         ios: { x: 0, y: 500 },
-      //       }
-      //     }),
-      //     getVisibilityFn: () => ({
-      //       desktop: () => false,
-      //       mobile: {
-      //         ios: () => true,
-      //         android: () => true,
-      //       }
-      //     }),
-      //     shouldCreate: () => ({
-      //       desktop: () => false,
-      //       mobile: {
-      //         ios: () => true,
-      //         android: () => true,
-      //       }
-      //     }),
-      //     getButtons: () => ({
-      //       desktop: () => [],
-      //       mobile: {
-      //         ios: pluginButtons.filter(({ buttonSettings }) => buttonSettings.toolbars.includes(TOOLBARS.FOOTER))
-      //         .map(({ component }) => component),
-      //         android: () => [],
-      //       }
-      //     }),
-      //   },
-      //   {
-      //     name: TOOLBARS.STATIC,
-      //     getPositionOffset: () => ({
-      //       desktop: { x: 40, y: 40 },
-      //       mobile: {
-      //         ios: { x: 40, y: 40 },
-      //         android: { x: 50, y: 50 },
-      //       }
-      //     }),
-      //     getVisibilityFn: () => ({
-      //       desktop: () => false,
-      //       mobile: {
-      //         ios: () => true,
-      //         android: () => true,
-      //       }
-      //     }),
-      //   }
-      // ]
-    };
     const mockUpload = (files, updateEntity) => {
       //mock upload
       const testItem = testImages[Math.floor(Math.random() * testImages.length)];
@@ -351,7 +233,7 @@ class App extends Component {
                   onChange={this.onChange}
                   helpers={this.helpers}
                   plugins={this.plugins}
-                  config={this.config}
+                  config={PluginsConfig}
                   editorState={this.state.editorState}
                   // initialState={this.state.initialState}
                   readOnly={this.state.readOnly}

--- a/examples/editor/src/PluginsConfig.js
+++ b/examples/editor/src/PluginsConfig.js
@@ -1,0 +1,118 @@
+import { CODE_BLOCK_TYPE } from 'wix-rich-content-plugin-code-block';
+import { DIVIDER_TYPE } from 'wix-rich-content-plugin-divider';
+import { EXTERNAL_EMOJI_TYPE } from 'wix-rich-content-plugin-emoji';
+import { GALLERY_TYPE } from 'wix-rich-content-plugin-gallery';
+import { HASHTAG_TYPE } from 'wix-rich-content-plugin-hashtag';
+import { HTML_TYPE } from 'wix-rich-content-plugin-html';
+import { IMAGE_TYPE } from 'wix-rich-content-plugin-image';
+import { LINK_TYPE } from 'wix-rich-content-plugin-link';
+import { VIDEO_TYPE } from 'wix-rich-content-plugin-video';
+import { EXTERNAL_MENTIONS_TYPE } from 'wix-rich-content-plugin-mentions';
+
+const uiSettings = {
+  blankTargetToggleVisibilityFn: () => true,
+  nofollowRelToggleVisibilityFn: () => true
+};
+
+export default {
+  [HASHTAG_TYPE]: {
+    createHref: decoratedText =>
+      `/search/posts?query=${encodeURIComponent('#')}${decoratedText}`,
+    onClick: (event, text) => {
+      event.preventDefault();
+      console.log(`'${text}' hashtag clicked!`);
+    },
+  },
+  [HTML_TYPE]: {
+    htmlIframeSrc: 'http://localhost:3000/static/html-plugin-embed.html',
+    // showInsertButtons: false,
+  },
+  [EXTERNAL_MENTIONS_TYPE]: {
+    onMentionClick: mention => console.log({ mention }),
+    getMentions: (searchQuery) => new Promise(resolve =>
+      setTimeout(() => resolve([
+          { name: searchQuery, slug: searchQuery },
+          { name: 'Test One', slug: 'testone' },
+          { name: 'Test Two', slug: 'testwo', avatar: 'https://via.placeholder.com/100x100?text=Image=50' },
+        ]),
+        250),
+    ),
+  },
+  [LINK_TYPE]: { },
+  [CODE_BLOCK_TYPE]: { },
+  [DIVIDER_TYPE]: { },
+  [EXTERNAL_EMOJI_TYPE]: { },
+  [GALLERY_TYPE]: { },
+  [IMAGE_TYPE]: { },
+  [VIDEO_TYPE]: { },
+  uiSettings,
+  // getToolbarSettings: ({ pluginButtons, textButtons }) => [
+  //   {
+  //     name: TOOLBARS.SIDE,
+  //     getVisibilityFn: () => ({
+  //       desktop: () => true,
+  //       mobile: {
+  //         ios: () => true,
+  //         android: () => true,
+  //       }
+  //     }),
+  //   },
+  //   {
+  //     name: TOOLBARS.MOBILE,
+  //     shouldCreate: () => ({
+  //       desktop: false,
+  //       mobile: {
+  //         ios: false,
+  //         android: false,
+  //       }
+  //     }),
+  //   },
+  //   {
+  //     name: TOOLBARS.FOOTER,
+  //     getPositionOffset: () => ({
+  //       mobile: {
+  //         ios: { x: 0, y: 500 },
+  //       }
+  //     }),
+  //     getVisibilityFn: () => ({
+  //       desktop: () => false,
+  //       mobile: {
+  //         ios: () => true,
+  //         android: () => true,
+  //       }
+  //     }),
+  //     shouldCreate: () => ({
+  //       desktop: () => false,
+  //       mobile: {
+  //         ios: () => true,
+  //         android: () => true,
+  //       }
+  //     }),
+  //     getButtons: () => ({
+  //       desktop: () => [],
+  //       mobile: {
+  //         ios: pluginButtons.filter(({ buttonSettings }) => buttonSettings.toolbars.includes(TOOLBARS.FOOTER))
+  //         .map(({ component }) => component),
+  //         android: () => [],
+  //       }
+  //     }),
+  //   },
+  //   {
+  //     name: TOOLBARS.STATIC,
+  //     getPositionOffset: () => ({
+  //       desktop: { x: 40, y: 40 },
+  //       mobile: {
+  //         ios: { x: 40, y: 40 },
+  //         android: { x: 50, y: 50 },
+  //       }
+  //     }),
+  //     getVisibilityFn: () => ({
+  //       desktop: () => false,
+  //       mobile: {
+  //         ios: () => true,
+  //         android: () => true,
+  //       }
+  //     }),
+  //   }
+  // ]
+};

--- a/packages/common/src/Base/baseToolbarButton.jsx
+++ b/packages/common/src/Base/baseToolbarButton.jsx
@@ -55,7 +55,7 @@ class BaseToolbarButton extends React.Component {
       return;
     }
 
-    const { componentState, keyName, helpers, pubsub, theme, t, onClick, anchorTarget, relValue, ...otherProps } = this.props;
+    const { componentState, keyName, helpers, pubsub, theme, t, onClick, anchorTarget, relValue, uiSettings, ...otherProps } = this.props;
 
     if (this.props.type === BUTTONS.FILES && helpers && helpers.handleFileSelection) {
       const multiple = !!this.props.multiple;
@@ -91,6 +91,7 @@ class BaseToolbarButton extends React.Component {
           relValue,
           t,
           theme: theme || {},
+          uiSettings,
           ...otherProps,
         };
         helpers.openModal(modalProps);
@@ -241,6 +242,7 @@ BaseToolbarButton.propTypes = {
   displayPanel: PropTypes.func.isRequired,
   displayInlinePanel: PropTypes.func.isRequired,
   hideInlinePanel: PropTypes.func.isRequired,
+  uiSettings: PropTypes.object,
 };
 
 export default BaseToolbarButton;

--- a/packages/common/src/Base/buttons/BlockLinkButton.jsx
+++ b/packages/common/src/Base/buttons/BlockLinkButton.jsx
@@ -22,7 +22,8 @@ class BlockLinkButton extends Component {
       componentState,
       anchorTarget,
       relValue,
-      t
+      t,
+      uiSettings
     } = this.props;
     const modalStyles = getModalStyles({ fullScreen: false });
     if (isMobile) {
@@ -38,7 +39,8 @@ class BlockLinkButton extends Component {
           anchorTarget,
           relValue,
           modalName: EditorModals.MOBILE_BLOCK_LINK_MODAL,
-          hidePopup: helpers.closeModal
+          hidePopup: helpers.closeModal,
+          uiSettings
         };
         helpers.openModal(modalProps);
       } else {
@@ -52,6 +54,7 @@ class BlockLinkButton extends Component {
         relValue,
         theme,
         t,
+        uiSettings
       };
       const BlockLinkPanelWithProps = decorateComponentWithProps(BlockLinkPanel, linkPanelProps);
       onOverrideContent(BlockLinkPanelWithProps);
@@ -84,6 +87,7 @@ BlockLinkButton.propTypes = {
   relValue: PropTypes.string,
   t: PropTypes.func,
   tabIndex: PropTypes.number,
+  uiSettings: PropTypes.object,
 };
 
 export default BlockLinkButton;

--- a/packages/common/src/Base/buttons/BlockLinkPanel.jsx
+++ b/packages/common/src/Base/buttons/BlockLinkPanel.jsx
@@ -6,7 +6,7 @@ import LinkPanelContainer from '../../Components/LinkPanelContainer';
 
 class BlockLinkPanel extends Component {
   componentDidMount() {
-    const { anchorTarget, relValue, theme, t } = this.props;
+    const { anchorTarget, relValue, theme, t, uiSettings } = this.props;
     const componentLink = this.props.pubsub.get('componentLink');
     const { url, targetBlank, nofollow } = componentLink || {};
     const linkContainerProps = {
@@ -22,6 +22,7 @@ class BlockLinkPanel extends Component {
       onCancel: this.hideLinkPanel,
       onDelete: this.deleteLink,
       onOverrideContent: this.props.onOverrideContent,
+      uiSettings,
     };
 
     const LinkPanelContainerWithProps = decorateComponentWithProps(LinkPanelContainer, linkContainerProps);
@@ -58,6 +59,7 @@ BlockLinkPanel.propTypes = {
   anchorTarget: PropTypes.string,
   relValue: PropTypes.string,
   t: PropTypes.func,
+  uiSettings: PropTypes.object,
 };
 
 export default BlockLinkPanel;

--- a/packages/common/src/Base/createBasePlugin.jsx
+++ b/packages/common/src/Base/createBasePlugin.jsx
@@ -64,6 +64,7 @@ const createBasePlugin = (config = {}, underlyingPlugin) => {
   const helpers = config.helpers || {};
   const isMobile = config.isMobile || false;
   const { t, anchorTarget, relValue } = config;
+
   const toolbarTheme = { ...getToolbarTheme(config.theme, 'plugin'), ...config.theme };
   const Toolbar = config.toolbar && config.toolbar.InlineButtons && createToolbar({
     buttons: {
@@ -78,6 +79,7 @@ const createBasePlugin = (config = {}, underlyingPlugin) => {
     relValue,
     t,
     name: config.toolbar.name,
+    uiSettings: config.uiSettings,
   });
   const InsertPluginButtons =
     settings.showInsertButtons && config.toolbar && config.toolbar.InsertButtons && config.toolbar.InsertButtons.map(button => ({

--- a/packages/common/src/Base/createBaseToolbar.jsx
+++ b/packages/common/src/Base/createBaseToolbar.jsx
@@ -43,7 +43,7 @@ const getStructure = (buttons, isMobile) => {
     button => button.desktop !== false);
 };
 
-export default function createToolbar({ buttons, theme, pubsub, helpers, isMobile, anchorTarget, relValue, t, name }) {
+export default function createToolbar({ buttons, theme, pubsub, helpers, isMobile, anchorTarget, relValue, t, name, uiSettings }) {
   class BaseToolbar extends Component {
     constructor(props) {
       super(props);
@@ -240,6 +240,7 @@ export default function createToolbar({ buttons, theme, pubsub, helpers, isMobil
               anchorTarget={anchorTarget}
               relValue={relValue}
               t={t}
+              uiSettings={uiSettings}
             />
           );
         case BUTTONS.DELETE:
@@ -269,6 +270,7 @@ export default function createToolbar({ buttons, theme, pubsub, helpers, isMobil
               displayInlinePanel={this.displayInlinePanel}
               hideInlinePanel={this.hidePanels}
               {...buttonProps}
+              uiSettings={uiSettings}
             />
           );
       }

--- a/packages/common/src/Components/LinkPanel.jsx
+++ b/packages/common/src/Components/LinkPanel.jsx
@@ -111,9 +111,9 @@ class LinkPanel extends Component {
 
   render() {
     const { styles } = this;
-    const { isImageSettings, theme, anchorTarget, relValue, ariaProps } = this.props;
-    const showTargetBlankCheckbox = anchorTarget !== '_blank';
-    const showRelValueCheckbox = relValue !== 'nofollow';
+    const { isImageSettings, theme, anchorTarget, relValue, ariaProps, uiSettings } = this.props;
+    const showTargetBlankCheckbox = uiSettings.blankTargetToggleVisibilityFn(anchorTarget);
+    const showRelValueCheckbox = uiSettings.nofollowRelToggleVisibilityFn(relValue);
 
     const textInputClassName = classNames(styles.linkPanel_textInput,
       {
@@ -174,5 +174,6 @@ LinkPanel.propTypes = {
   onValidateUrl: PropTypes.func,
   onEnter: PropTypes.func,
   onEscape: PropTypes.func,
+  uiSettings: PropTypes.object,
 };
 export default LinkPanel;

--- a/packages/common/src/Components/LinkPanelContainer.jsx
+++ b/packages/common/src/Components/LinkPanelContainer.jsx
@@ -49,7 +49,7 @@ class LinkPanelContainer extends PureComponent {
 
   render() {
     const { styles } = this;
-    const { url, targetBlank, nofollow, theme, isActive, anchorTarget, relValue, isMobile, t, ariaProps, tabIndex } = this.props;
+    const { url, targetBlank, nofollow, theme, isActive, anchorTarget, relValue, isMobile, t, ariaProps, tabIndex, uiSettings } = this.props;
     const doneButtonText = t('LinkPanelContainer_DoneButton');
     const cancelButtonText = t('LinkPanelContainer_CancelButton');
     const removeButtonText = t('LinkPanelContainer_RemoveButton');
@@ -68,7 +68,7 @@ class LinkPanelContainer extends PureComponent {
           <LinkPanel
             onEnter={this.onDoneClick.bind(this)} onEscape={this.onCancelClick.bind(this)}
             ref={this.setLinkPanel} theme={theme} url={url} targetBlank={targetBlank} anchorTarget={anchorTarget}
-            relValue={relValue} nofollow={nofollow} t={t} ariaProps={linkPanelAriaProps}
+            relValue={relValue} nofollow={nofollow} t={t} ariaProps={linkPanelAriaProps} uiSettings={uiSettings}
           />
           <div className={styles.linkPanel_actionsDivider} role="separator"/>
         </div>
@@ -118,6 +118,7 @@ LinkPanelContainer.propTypes = {
   t: PropTypes.func,
   ariaProps: PropTypes.object,
   tabIndex: PropTypes.number,
+  uiSettings: PropTypes.object,
 };
 
 export default LinkPanelContainer;

--- a/packages/editor/src/RichContentEditor/RichContentEditor.jsx
+++ b/packages/editor/src/RichContentEditor/RichContentEditor.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { EditorState, convertFromRaw, CompositeDecorator } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import get from 'lodash/get';
+import merge from 'lodash/merge';
 import includes from 'lodash/includes';
 import Measure from 'react-measure';
 import { translate } from 'react-i18next';
@@ -34,6 +35,12 @@ class RichContentEditor extends Component {
       theme: props.theme || {}
     };
     this.refId = Math.floor(Math.random() * 9999);
+
+    props.config.uiSettings = merge({
+      blankTargetToggleVisibilityFn: anchorTarget => anchorTarget !== '_blank',
+      nofollowRelToggleVisibilityFn: relValue => relValue !== 'nofollow'
+    }, props.config.uiSettings || {});
+
     this.initPlugins();
   }
 
@@ -47,6 +54,7 @@ class RichContentEditor extends Component {
       relValue,
       t,
     } = this.props;
+
     const { theme } = this.state;
     const getEditorState = () => this.state.editorState;
     const setEditorState = editorState => this.setState({ editorState });
@@ -85,7 +93,8 @@ class RichContentEditor extends Component {
       setEditorState: editorState => this.setState({ editorState }),
       t,
       refId: this.refId,
-      getToolbarSettings: config.getToolbarSettings
+      getToolbarSettings: config.getToolbarSettings,
+      uiSettings: config.uiSettings
     });
   }
 
@@ -359,6 +368,10 @@ RichContentEditor.propTypes = {
   textAlignment: PropTypes.oneOf(['left', 'right', 'center']),
   handleBeforeInput: PropTypes.func,
   handlePastedText: PropTypes.func,
+};
+
+RichContentEditor.defaultProps = {
+  config: {}
 };
 
 export default translate(null, { withRef: true })(RichContentEditor);

--- a/packages/editor/src/RichContentEditor/Toolbars/InlineToolbar/createInlineTextToolbar.jsx
+++ b/packages/editor/src/RichContentEditor/Toolbars/InlineToolbar/createInlineTextToolbar.jsx
@@ -14,10 +14,11 @@ export default config => {
     relValue,
     t,
     offset,
-    visibilityFn
+    visibilityFn,
+    uiSettings,
   } = config;
 
-  const structure = getTextButtonsFromList({ buttons, textPluginButtons, pubsub, theme, t });
+  const structure = getTextButtonsFromList({ buttons, textPluginButtons, pubsub, theme, t, uiSettings });
 
   return createInlineToolbar({
     name: 'InlineTextToolbar',
@@ -31,6 +32,7 @@ export default config => {
     relValue,
     t,
     offset,
-    visibilityFn
+    visibilityFn,
+    uiSettings
   });
 };

--- a/packages/editor/src/RichContentEditor/Toolbars/MobileBlockLinkModal.jsx
+++ b/packages/editor/src/RichContentEditor/Toolbars/MobileBlockLinkModal.jsx
@@ -22,7 +22,7 @@ export default class MobileBlockLinkModal extends Component {
   }
 
   render() {
-    const { pubsub, theme, isMobile, anchorTarget, relValue, t } = this.props;
+    const { pubsub, theme, isMobile, anchorTarget, relValue, t, uiSettings } = this.props;
     const componentLink = pubsub.get('componentLink');
     const { url, target, rel } = componentLink || {};
     const targetBlank = target === '_blank';
@@ -40,6 +40,7 @@ export default class MobileBlockLinkModal extends Component {
         onDone={this.wrapBlockInLink}
         onCancel={this.hidePopup}
         onDelete={this.deleteLink}
+        uiSettings={uiSettings}
         t={t}
       />
     );
@@ -57,4 +58,5 @@ MobileBlockLinkModal.propTypes = {
   anchorTarget: PropTypes.string,
   relValue: PropTypes.string,
   t: PropTypes.func,
+  uiSettings: PropTypes.object,
 };

--- a/packages/editor/src/RichContentEditor/Toolbars/MobileLinkModal.jsx
+++ b/packages/editor/src/RichContentEditor/Toolbars/MobileLinkModal.jsx
@@ -19,7 +19,8 @@ export default class MobileLinkModal extends Component {
       onDone,
       onCancel,
       onDelete,
-      t
+      t,
+      uiSettings
     } = this.props;
     const mobileLinkModalTitle = t('MobileLinkModal_Title');
     return (
@@ -33,7 +34,7 @@ export default class MobileLinkModal extends Component {
         <LinkPanelContainer
           url={url} targetBlank={targetBlank} anchorTarget={anchorTarget} relValue={relValue} nofollow={nofollow} theme={theme}
           isActive={isActive} isMobile={isMobile} onDone={onDone} onCancel={onCancel} onDelete={onDelete} t={t}
-          ariaProps={{ 'aria-labelledby': 'mob_link_modal_hdr' }}
+          ariaProps={{ 'aria-labelledby': 'mob_link_modal_hdr' }} uiSettings={uiSettings}
         />
       </div>
     );
@@ -53,4 +54,5 @@ MobileLinkModal.propTypes = {
   relValue: PropTypes.string,
   nofollow: PropTypes.bool,
   t: PropTypes.func,
+  uiSettings: PropTypes.object,
 };

--- a/packages/editor/src/RichContentEditor/Toolbars/MobileTextLinkModal.jsx
+++ b/packages/editor/src/RichContentEditor/Toolbars/MobileTextLinkModal.jsx
@@ -27,7 +27,7 @@ export default class MobileTextLinkModal extends Component {
   }
 
   render() {
-    const { getEditorState, theme, isMobile, anchorTarget, relValue, t } = this.props;
+    const { getEditorState, theme, isMobile, anchorTarget, relValue, t, uiSettings } = this.props;
     const linkData = getLinkDataInSelection(getEditorState());
     const { url, target, rel } = linkData || {};
     const targetBlank = target === '_blank';
@@ -45,6 +45,7 @@ export default class MobileTextLinkModal extends Component {
         onDone={this.createLinkEntity}
         onCancel={this.hidePopup}
         onDelete={this.deleteLink}
+        uiSettings={uiSettings}
         t={t}
       />
     );
@@ -63,4 +64,6 @@ MobileTextLinkModal.propTypes = {
   anchorTarget: PropTypes.string,
   relValue: PropTypes.string,
   t: PropTypes.func,
+  uiSettings: PropTypes.object,
+
 };

--- a/packages/editor/src/RichContentEditor/Toolbars/StaticToolbar/StaticToolbar.jsx
+++ b/packages/editor/src/RichContentEditor/Toolbars/StaticToolbar/StaticToolbar.jsx
@@ -21,7 +21,8 @@ export default class StaticToolbar extends React.Component {
       x: PropTypes.number,
       y: PropTypes.number,
     }),
-    visibilityFn: PropTypes.func
+    visibilityFn: PropTypes.func,
+    uiSettings: PropTypes.object,
   };
 
   constructor(props) {
@@ -68,7 +69,7 @@ export default class StaticToolbar extends React.Component {
       }
     }
 
-    const { theme, structure, helpers, isMobile, linkModal, anchorTarget, relValue, t, dataHook, id, offset } = this.props;
+    const { theme, structure, helpers, isMobile, linkModal, anchorTarget, relValue, t, dataHook, id, offset, uiSettings } = this.props;
     const { showLeftArrow, showRightArrow, overrideContent: OverrideContent, extendContent: ExtendContent } = this.state;
     const hasArrow = showLeftArrow || showRightArrow;
     const { toolbarStyles } = theme || {};
@@ -100,6 +101,7 @@ export default class StaticToolbar extends React.Component {
       setEditorState: pubsub.get('setEditorState'),
       onOverrideContent: this.onOverrideContent,
       onExtendContent: this.onExtendContent,
+      uiSettings,
     };
 
     let style = {};

--- a/packages/editor/src/RichContentEditor/Toolbars/StaticToolbar/createMobileToolbar.jsx
+++ b/packages/editor/src/RichContentEditor/Toolbars/StaticToolbar/createMobileToolbar.jsx
@@ -9,7 +9,7 @@ import separatorStyles from '../../../../statics/styles/mobile-toolbar-separator
 
 const createMobileToolbar = ({
   buttons, textPluginButtons, pluginButtons, helpers, pubsub, getEditorState, setEditorState,
-  anchorTarget, relValue, theme, t, offset, visibilityFn
+  anchorTarget, relValue, theme, t, offset, visibilityFn, uiSettings
 }) => {
   const mobileTheme = getMobileTheme(theme);
   return createStaticToolbar({
@@ -17,12 +17,24 @@ const createMobileToolbar = ({
     t,
     name: 'MobileToolbar',
     theme: mobileTheme,
-    structure: getMobileButtons({ buttons, textPluginButtons, pluginButtons, helpers, pubsub, getEditorState, setEditorState, mobileTheme, t }),
+    structure: getMobileButtons({
+      buttons,
+      textPluginButtons,
+      pluginButtons,
+      helpers,
+      pubsub,
+      getEditorState,
+      setEditorState,
+      mobileTheme,
+      t,
+      uiSettings
+    }),
     anchorTarget,
     relValue,
     isMobile: true,
     offset,
-    visibilityFn
+    visibilityFn,
+    uiSettings
   });
 };
 
@@ -102,13 +114,24 @@ const getMobileTheme = theme => {
   };
 };
 
-const getMobileButtons = ({ buttons, textPluginButtons, pluginButtons, helpers, pubsub, getEditorState, setEditorState, mobileTheme, t }) => {
+const getMobileButtons = ({
+  buttons,
+  textPluginButtons,
+  pluginButtons,
+  helpers,
+  pubsub,
+  getEditorState,
+  setEditorState,
+  mobileTheme,
+  t,
+  uiSettings
+}) => {
   const addPluginIndex = buttons.findIndex(b => b === 'AddPlugin');
   if (addPluginIndex !== -1) {
     buttons.splice(addPluginIndex, 1);
   }
 
-  const structure = getTextButtonsFromList({ buttons, textPluginButtons, theme: mobileTheme, isMobile: true, t });
+  const structure = getTextButtonsFromList({ buttons, textPluginButtons, theme: mobileTheme, isMobile: true, t, uiSettings });
 
   if (addPluginIndex !== -1) {
     const addAddPluginButton = pluginButtons && pluginButtons.length;

--- a/packages/editor/src/RichContentEditor/Toolbars/StaticToolbar/createStaticTextToolbar.jsx
+++ b/packages/editor/src/RichContentEditor/Toolbars/StaticToolbar/createStaticTextToolbar.jsx
@@ -69,9 +69,23 @@ const getStaticTextTheme = theme => {
   };
 };
 
-export default ({ buttons, textPluginButtons, pubsub, theme, isMobile, helpers, anchorTarget, relValue, t, refId, offset, visibilityFn }) => {
+export default ({
+  buttons,
+  textPluginButtons,
+  pubsub,
+  theme,
+  isMobile,
+  helpers,
+  anchorTarget,
+  relValue,
+  t,
+  refId,
+  offset,
+  visibilityFn,
+  uiSettings
+}) => {
   const staticTextTheme = getStaticTextTheme(theme);
-  const structure = getTextButtonsFromList({ buttons, textPluginButtons, pubsub, theme: staticTextTheme, t });
+  const structure = getTextButtonsFromList({ buttons, textPluginButtons, pubsub, theme: staticTextTheme, t, uiSettings });
   const id = getStaticTextToolbarId(refId);
 
   return createStaticToolbar({
@@ -87,6 +101,7 @@ export default ({ buttons, textPluginButtons, pubsub, theme, isMobile, helpers, 
     t,
     id,
     offset,
-    visibilityFn
+    visibilityFn,
+    uiSettings,
   });
 };

--- a/packages/editor/src/RichContentEditor/Toolbars/buttons/utils/getTextButtonsFromList.js
+++ b/packages/editor/src/RichContentEditor/Toolbars/buttons/utils/getTextButtonsFromList.js
@@ -16,7 +16,7 @@ import {
 import createThemedSeparator from './createThemedSeparator';
 import HeadingSwitchButton from '../inline-styling/HeadingSwitchButton';
 
-export default ({ buttons, theme, t, isMobile, textPluginButtons }) => {
+export default ({ buttons, theme, t, isMobile, textPluginButtons, uiSettings }) => {
   const themedSeparator = horizontal => createThemedSeparator({ theme, horizontal });
 
   const buttonByName = {
@@ -44,5 +44,5 @@ export default ({ buttons, theme, t, isMobile, textPluginButtons }) => {
 
   const structure = buttons.map(buttonName => buttonMap[buttonName]).filter(b => b !== undefined);
 
-  return structure.map(b => decorateComponentWithProps(b, { t, isMobile }));
+  return structure.map(b => decorateComponentWithProps(b, { t, isMobile, uiSettings }));
 };

--- a/packages/editor/src/RichContentEditor/Toolbars/createEditorToolbars.js
+++ b/packages/editor/src/RichContentEditor/Toolbars/createEditorToolbars.js
@@ -27,7 +27,8 @@ const createEditorToolbars = config => {
     setEditorState,
     t,
     refId,
-    getToolbarSettings = () => []
+    getToolbarSettings = () => [],
+    uiSettings,
   } = config;
   const { pluginButtons, pluginTextButtons } = buttons;
 
@@ -67,6 +68,7 @@ const createEditorToolbars = config => {
         setEditorState,
         pluginButtons,
         anchorTarget,
+        uiSettings,
         relValue,
         isMobile,
         helpers,

--- a/packages/plugin-code-block/src/createCodeBlockPlugin.js
+++ b/packages/plugin-code-block/src/createCodeBlockPlugin.js
@@ -1,15 +1,8 @@
 import CodeUtils from 'draft-js-code';
-import merge from 'lodash/merge';
 import { createBasePlugin } from 'wix-rich-content-common';
 import { CODE_BLOCK_TYPE } from './types';
 import PrismDecorator from './PrismDecorator';
 import createCodeBlockToolbar from './toolbar/createCodeBlockToolbar';
-
-const defaultSettings = {
-  position: {
-    mobile: 7,
-  },
-};
 
 const createUnderlyingPlugin = ({ theme }) => ({
   keyBindingFn: (event, { getEditorState }) => {
@@ -63,7 +56,6 @@ const createUnderlyingPlugin = ({ theme }) => ({
 const createCodeBlockPlugin = (config = {}) => {
   const type = CODE_BLOCK_TYPE;
   const {
-    decorator,
     helpers,
     theme,
     isMobile,
@@ -72,9 +64,10 @@ const createCodeBlockPlugin = (config = {}) => {
     relValue,
     getEditorState,
     setEditorState,
-    codeBlock: userSettings = {},
+    [type]: settings = {},
+    ...rest
   } = config;
-  const settings = merge(defaultSettings, userSettings);
+
   const plugin = createUnderlyingPlugin({ theme });
   const toolbar = createCodeBlockToolbar({
     helpers,
@@ -85,12 +78,10 @@ const createCodeBlockPlugin = (config = {}) => {
     relValue,
     getEditorState,
     setEditorState,
-    settings,
   });
 
   return createBasePlugin(
     {
-      decorator,
       theme,
       toolbar,
       type,
@@ -99,6 +90,8 @@ const createCodeBlockPlugin = (config = {}) => {
       anchorTarget,
       relValue,
       t,
+      settings,
+      ...rest
     },
     plugin,
   );

--- a/packages/plugin-code-block/src/toolbar/createCodeBlockToolbar.js
+++ b/packages/plugin-code-block/src/toolbar/createCodeBlockToolbar.js
@@ -3,12 +3,14 @@ import TextCodeBlockButton from './TextCodeBlockButton';
 import { CODE_BLOCK_TYPE } from '../types';
 import { toggleBlockTypeAndEnsureSpaces } from './blockTypeModifiers';
 
-export default ({ setEditorState, settings }) => ({
+export default ({ setEditorState }) => ({
   TextButtonMapper: () => ({
     CodeBlock: {
       component: TextCodeBlockButton,
       isMobile: true,
-      position: settings.position,
+      position: {
+        mobile: 7
+      },
       keyBindings: [{
         keyCommand: {
           command: 'code-block',

--- a/packages/plugin-divider/src/createDividerPlugin.js
+++ b/packages/plugin-divider/src/createDividerPlugin.js
@@ -6,15 +6,14 @@ import createToolbar from './toolbar';
 import Styles from '../statics/styles/default-styles.scss';
 
 const createDividerPlugin = (config = {}) => {
-  const { decorator, helpers, theme, isMobile, t, anchorTarget, relValue, divider: settings } = config;
+  const type = DIVIDER_TYPE;
+  const { helpers, theme, t, [type]: settings = {}, ...rest } = config;
   const styles = mergeStyles({ styles: Styles, theme });
-
   return createBasePlugin({
     component: DividerComponent,
-    decorator,
     settings,
     theme,
-    type: DIVIDER_TYPE,
+    type,
     toolbar: createToolbar({
       helpers,
       styles,
@@ -22,10 +21,8 @@ const createDividerPlugin = (config = {}) => {
       t
     }),
     helpers,
-    isMobile,
-    anchorTarget,
-    relValue,
     t,
+    ...rest
   });
 };
 

--- a/packages/plugin-emoji/src/createEmojiPlugin.jsx
+++ b/packages/plugin-emoji/src/createEmojiPlugin.jsx
@@ -8,7 +8,7 @@ import * as Styles from '../statics/emoji.scss';
 
 const createExternalEmojiPlugin = (config = {}) => {
   const type = EXTERNAL_EMOJI_TYPE;
-  const { decorator, helpers, theme, isMobile, t, anchorTarget, relValue } = config;
+  const { helpers, theme, isMobile, t, [type]: settings = {}, ...rest } = config;
   const styles = mergeStyles({ styles: Styles.default, theme });
 
   const plugin = createEmojiPlugin({
@@ -39,16 +39,14 @@ const createExternalEmojiPlugin = (config = {}) => {
 
   return createBasePlugin(
     {
-      decorator,
-      theme,
       type,
       toolbar,
       inlineModals,
       helpers,
       isMobile,
-      anchorTarget,
-      relValue,
       t,
+      settings,
+      ...rest
     },
     plugin,
   );

--- a/packages/plugin-gallery/src/components/gallery-controls/gallery-image-settings.js
+++ b/packages/plugin-gallery/src/components/gallery-controls/gallery-image-settings.js
@@ -138,7 +138,7 @@ class ImageSettings extends Component {
 
   render() {
     const styles = this.styles;
-    const { handleFileSelection, onCancel, theme, isMobile, t, anchorTarget, relValue } = this.props;
+    const { handleFileSelection, onCancel, theme, isMobile, t, anchorTarget, relValue, uiSettings } = this.props;
     const { images } = this.state;
     const selectedImage = images[this.state.selectedIndex];
     const { url, target, rel, intermediateUrl } = (!isEmpty(selectedImage.metadata.link) ? selectedImage.metadata.link : {});
@@ -221,7 +221,7 @@ class ImageSettings extends Component {
               <LinkPanel
                 theme={theme} url={url} targetBlank={targetBlank} nofollow={nofollow} anchorTarget={anchorTarget} relValue={relValue}
                 isImageSettings t={t} ariaProps={{ 'aria-labelledby': 'gallery_image_link_lbl' }} intermediateUrl={intermediateUrl}
-                onIntermediateUrlChange={this.onImageIntermediateUrlChange} onValidateUrl={this.onValidateUrl}
+                onIntermediateUrlChange={this.onImageIntermediateUrlChange} onValidateUrl={this.onValidateUrl} uiSettings={uiSettings}
                 onUrlChange={this.onImageUrlChange} onTargetBlankChange={this.onImageTargetChange} onNofollowChange={this.onImageRelChange}
               />
             </SettingsSection>
@@ -255,6 +255,7 @@ ImageSettings.propTypes = {
   t: PropTypes.func,
   anchorTarget: PropTypes.string,
   relValue: PropTypes.string,
+  uiSettings: PropTypes.object,
 };
 
 export default ImageSettings;

--- a/packages/plugin-gallery/src/components/gallery-controls/gallery-items-sortable.js
+++ b/packages/plugin-gallery/src/components/gallery-controls/gallery-items-sortable.js
@@ -388,7 +388,7 @@ export class SortableComponent extends Component {
   }
 
   render() {
-    const { handleFileSelection: shouldHandleFileSelection, theme, t, relValue, anchorTarget } = this.props;
+    const { handleFileSelection: shouldHandleFileSelection, theme, t, relValue, anchorTarget, uiSettings } = this.props;
     return !!this.state.items && (
       !this.state.imageSettingsVisible ? (
         <div>
@@ -435,6 +435,7 @@ export class SortableComponent extends Component {
             isMobile={this.props.isMobile}
             relValue={relValue}
             anchorTarget={anchorTarget}
+            uiSettings={uiSettings}
           />
         </div>
       )
@@ -455,4 +456,5 @@ SortableComponent.propTypes = {
   t: PropTypes.func,
   relValue: PropTypes.string,
   anchorTarget: PropTypes.string,
+  uiSettings: PropTypes.object,
 };

--- a/packages/plugin-gallery/src/components/gallery-settings-modal.js
+++ b/packages/plugin-gallery/src/components/gallery-settings-modal.js
@@ -40,7 +40,7 @@ class ManageMediaSection extends Component {
   };
 
   render() {
-    const { helpers, store, t, relValue, anchorTarget, isMobile } = this.props;
+    const { helpers, store, t, relValue, anchorTarget, isMobile, uiSettings } = this.props;
     const { handleFileSelection } = helpers;
 
     return (
@@ -57,6 +57,7 @@ class ManageMediaSection extends Component {
           relValue={relValue}
           anchorTarget={anchorTarget}
           isMobile={isMobile}
+          uiSettings={uiSettings}
         />
       </div>
     );
@@ -72,6 +73,7 @@ ManageMediaSection.propTypes = {
   t: PropTypes.func,
   anchorTarget: PropTypes.string,
   relValue: PropTypes.string,
+  uiSettings: PropTypes.object,
 };
 
 class AdvancedSettingsSection extends Component {
@@ -186,7 +188,7 @@ export class GallerySettingsModal extends Component {
 
   render() {
     const styles = this.styles;
-    const { pubsub, helpers, t, isMobile, anchorTarget, relValue } = this.props;
+    const { pubsub, helpers, t, isMobile, anchorTarget, relValue, uiSettings } = this.props;
     const { activeTab } = this.state;
     const componentData = pubsub.get('componentData');
     // console.log('MODAL_RENDER: ', componentData);
@@ -214,6 +216,7 @@ export class GallerySettingsModal extends Component {
               isMobile
               anchorTarget={anchorTarget}
               relValue={relValue}
+              uiSettings={uiSettings}
             /> : null }
           {activeTab === 'advanced_settings' ? <AdvancedSettingsSection theme={this.props.theme} data={componentData} store={pubsub.store} helpers={helpers} t={t} isMobile/> : null }
         </div>
@@ -234,6 +237,7 @@ export class GallerySettingsModal extends Component {
                   t={t}
                   anchorTarget={anchorTarget}
                   relValue={relValue}
+                  uiSettings={uiSettings}
                 />
               </Tab>
               <Tab label={this.tabName('advanced_settings', t)} value={'advanced_settings'} theme={this.props.theme}>
@@ -258,6 +262,7 @@ GallerySettingsModal.propTypes = {
   t: PropTypes.func,
   relValue: PropTypes.string,
   anchorTarget: PropTypes.string,
+  uiSettings: PropTypes.object,
 };
 
 export default GallerySettingsModal;

--- a/packages/plugin-gallery/src/createGalleryPlugin.js
+++ b/packages/plugin-gallery/src/createGalleryPlugin.js
@@ -4,15 +4,15 @@ import { Component } from './gallery-component';
 import { GALLERY_TYPE } from './types';
 
 const createGalleryPlugin = (config = {}) => {
-  const { decorator, helpers, theme, isMobile, t, anchorTarget, relValue, gallery: settings } = config;
+  const type = GALLERY_TYPE;
+  const { helpers, theme, t, anchorTarget, relValue, [type]: settings = {}, ...rest } = config;
 
   return createBasePlugin({
     component: Component,
-    decorator,
     settings,
     theme,
     t,
-    type: GALLERY_TYPE,
+    type,
     toolbar: createToolbar({
       helpers,
       t,
@@ -20,9 +20,9 @@ const createGalleryPlugin = (config = {}) => {
       relValue,
     }),
     helpers,
-    isMobile,
     anchorTarget,
     relValue,
+    ...rest
   });
 };
 

--- a/packages/plugin-hashtag/src/createHashtagPlugin.js
+++ b/packages/plugin-hashtag/src/createHashtagPlugin.js
@@ -4,15 +4,14 @@ import { Strategy, Component } from './decorator';
 
 const createHashtagPlugin = (config = {}) => {
   const type = HASHTAG_TYPE;
-  const { decorator, helpers, theme, isMobile, t, anchorTarget, relValue, hashtag } = config;
+  const { theme, [type]: settings = {}, ...rest } = config;
   const plugin = { decorators: [] };
 
-  const hashtagConfig = hashtag || {};
   const hashtagTheme = {
     hashtag: theme && theme.hashtag,
     hashtag_hover: theme && theme.hashtag_hover, //eslint-disable-line camelcase
   };
-  const hashtagProps = Object.assign({}, hashtagConfig, { theme: hashtagTheme });
+  const hashtagProps = Object.assign({}, settings, { theme: hashtagTheme });
 
   plugin.decorators.push({
     strategy: Strategy,
@@ -20,14 +19,10 @@ const createHashtagPlugin = (config = {}) => {
   });
 
   return createBasePlugin({
-    decorator,
     theme,
     type,
-    helpers,
-    isMobile,
-    anchorTarget,
-    relValue,
-    t
+    settings,
+    ...rest
   }, plugin);
 };
 

--- a/packages/plugin-html/src/createHtmlPlugin.js
+++ b/packages/plugin-html/src/createHtmlPlugin.js
@@ -4,13 +4,12 @@ import { Component } from './HtmlComponent';
 import { HTML_TYPE } from './types';
 
 const createHtmlPlugin = (config = {}) => {
-  const { decorator, helpers, theme, isMobile, t, anchorTarget, relValue, html: settings } = config;
+  const type = HTML_TYPE;
+  const { helpers, isMobile, t, [type]: settings = {}, ...rest } = config;
 
   return createBasePlugin({
     component: Component,
-    decorator,
     settings,
-    theme,
     type: HTML_TYPE,
     toolbar: createToolbar({
       helpers,
@@ -19,9 +18,8 @@ const createHtmlPlugin = (config = {}) => {
     }),
     helpers,
     isMobile,
-    anchorTarget,
-    relValue,
     t,
+    ...rest
   });
 };
 

--- a/packages/plugin-image/src/createImagePlugin.js
+++ b/packages/plugin-image/src/createImagePlugin.js
@@ -4,13 +4,11 @@ import { Component } from './image-component';
 import { IMAGE_TYPE, IMAGE_TYPE_LEGACY } from './types';
 
 const createImagePlugin = (config = {}) => {
-  const { decorator, helpers, t, theme, isMobile, anchorTarget, relValue, image: settings } = config;
+  const type = IMAGE_TYPE;
+  const { helpers, t, anchorTarget, relValue, [type]: settings = {}, uiSettings, ...rest } = config;
 
   return createBasePlugin({
     component: Component,
-    decorator,
-    settings,
-    theme,
     type: IMAGE_TYPE,
     legacyType: IMAGE_TYPE_LEGACY,
     toolbar: createToolbar({
@@ -18,12 +16,15 @@ const createImagePlugin = (config = {}) => {
       anchorTarget,
       relValue,
       t,
+      uiSettings
     }),
     helpers,
-    isMobile,
     anchorTarget,
     relValue,
+    settings,
+    uiSettings,
     t,
+    ...rest
   });
 };
 

--- a/packages/plugin-image/src/toolbar/createToolbar.js
+++ b/packages/plugin-image/src/toolbar/createToolbar.js
@@ -1,9 +1,9 @@
 import createInlineButtons from './inline-buttons';
 import createInsertButtons from './insert-buttons';
 
-export default function createToolbar({ helpers, t, anchorTarget, relValue }) {
+export default function createToolbar({ helpers, t, anchorTarget, relValue, uiSettings }) {
   return {
-    InlineButtons: createInlineButtons({ t, anchorTarget, relValue }),
+    InlineButtons: createInlineButtons({ t, anchorTarget, relValue, uiSettings }),
     InsertButtons: createInsertButtons({ helpers, t }),
     name: 'image',
   };

--- a/packages/plugin-image/src/toolbar/image-settings.js
+++ b/packages/plugin-image/src/toolbar/image-settings.js
@@ -99,7 +99,7 @@ class ImageSettings extends Component {
   };
 
   render() {
-    const { componentData, helpers, theme, t, anchorTarget, relValue, isMobile } = this.props;
+    const { componentData, helpers, theme, t, anchorTarget, relValue, isMobile, uiSettings } = this.props;
     const { config = {} } = componentData;
     const { src, metadata = {} } = this.state;
 
@@ -148,7 +148,7 @@ class ImageSettings extends Component {
               onChange={event => this.metadataUpdated(metadata, { caption: event.target.value })}
               dataHook="imageSettingsCaptionInput"
             />
-          </SettingsSection >
+          </SettingsSection>
           <SettingsSection theme={theme} className={this.styles.imageSettingsSection} ariaProps={{ 'aria-label': 'image alt text', role: 'region' }}>
             <InputWithLabel
               theme={theme}
@@ -163,7 +163,7 @@ class ImageSettings extends Component {
           <SettingsSection theme={theme} className={this.styles.imageSettingsSection} ariaProps={{ 'aria-label': 'image link', role: 'region' }}>
             <span id="image_settings_link_lbl" className={this.styles.inputWithLabel_label}>{linkLabel}</span>
             <LinkPanel
-              ref={this.setLinkPanel} theme={theme} url={url} targetBlank={targetBlank} nofollow={nofollow}
+              ref={this.setLinkPanel} theme={theme} url={url} targetBlank={targetBlank} nofollow={nofollow} uiSettings={uiSettings}
               isImageSettings anchorTarget={anchorTarget} relValue={relValue} t={t} ariaProps={{ 'aria-labelledby': 'image_settings_link_lbl' }}
             />
           </SettingsSection>
@@ -190,6 +190,7 @@ ImageSettings.propTypes = {
   anchorTarget: PropTypes.string,
   relValue: PropTypes.string,
   isMobile: PropTypes.bool,
+  uiSettings: PropTypes.object,
 };
 
 export default ImageSettings;

--- a/packages/plugin-image/src/toolbar/inline-buttons.jsx
+++ b/packages/plugin-image/src/toolbar/inline-buttons.jsx
@@ -4,7 +4,7 @@ import { MediaReplaceIcon } from '../icons';
 
 const modalStyles = getModalStyles();
 
-export default ({ t, anchorTarget, relValue }) => {
+export default ({ t, anchorTarget, relValue, uiSettings }) => {
   return [
     { keyName: 'sizeOriginal', type: BUTTONS.SIZE_ORIGINAL, mobile: false },
     { keyName: 'sizeSmallCenter', type: BUTTONS.SIZE_SMALL_CENTER, mobile: false },
@@ -26,6 +26,7 @@ export default ({ t, anchorTarget, relValue }) => {
       t,
       mobile: true,
       tooltipTextKey: 'SettingsButton_Tooltip',
+      uiSettings
     },
     {
       keyName: 'replace',

--- a/packages/plugin-link/src/createLinkPlugin.js
+++ b/packages/plugin-link/src/createLinkPlugin.js
@@ -1,31 +1,35 @@
 import createLinkifyPlugin from 'draft-js-linkify-plugin';
 import { createBasePlugin, decorateComponentWithProps } from 'wix-rich-content-common';
-import { EXTERNAL_LINK_TYPE } from './types';
+import { LINK_TYPE } from './types';
 import { Strategy, Component } from './LinkDecorator';
 import styles from '../statics/link-viewer.scss';
 import createLinkToolbar from './toolbar/createLinkToolbar';
 
 const createLinkPlugin = (config = {}) => {
-  const type = EXTERNAL_LINK_TYPE;
-  const { decorator, helpers, theme, isMobile, t, anchorTarget, relValue, getEditorState, setEditorState } = config;
+  const type = LINK_TYPE;
+  const {
+    theme,
+    anchorTarget,
+    relValue,
+    [type]: settings = {},
+    ...rest
+  } = config;
   const plugin = createLinkifyPlugin({ target: anchorTarget, rel: relValue, theme: theme || styles });
 
-  const toolbar = createLinkToolbar({ helpers, theme, isMobile, t, anchorTarget, relValue, getEditorState, setEditorState });
+  const toolbar = createLinkToolbar(config);
 
   plugin.decorators.push({
     strategy: Strategy,
     component: decorateComponentWithProps(Component, { className: theme.link, anchorTarget, relValue }),
   });
   return createBasePlugin({
-    decorator,
     theme,
     toolbar,
     type,
-    helpers,
-    isMobile,
     anchorTarget,
     relValue,
-    t
+    settings,
+    ...rest
   }, plugin);
 };
 

--- a/packages/plugin-link/src/toolbar/TextLinkButton.jsx
+++ b/packages/plugin-link/src/toolbar/TextLinkButton.jsx
@@ -17,7 +17,8 @@ export default class TextLinkButton extends Component {
       keyName,
       anchorTarget,
       relValue,
-      t
+      t,
+      uiSettings
     } = this.props;
     const modalStyles = getModalStyles({ fullScreen: false });
     if (isMobile || linkModal) {
@@ -33,7 +34,8 @@ export default class TextLinkButton extends Component {
           anchorTarget,
           relValue,
           modalName: EditorModals.MOBILE_TEXT_LINK_MODAL,
-          hidePopup: helpers.closeModal
+          hidePopup: helpers.closeModal,
+          uiSettings,
         };
         helpers.openModal(modalProps);
       } else {
@@ -47,6 +49,7 @@ export default class TextLinkButton extends Component {
         relValue,
         theme,
         t,
+        uiSettings
       };
       const TextLinkPanelWithProps = decorateComponentWithProps(TextLinkPanel, linkPanelProps);
       onOverrideContent(TextLinkPanelWithProps);
@@ -91,4 +94,5 @@ TextLinkButton.propTypes = {
   relValue: PropTypes.string,
   t: PropTypes.func,
   tabIndex: PropTypes.number,
+  uiSettings: PropTypes.object,
 };

--- a/packages/plugin-link/src/toolbar/TextLinkPanel.jsx
+++ b/packages/plugin-link/src/toolbar/TextLinkPanel.jsx
@@ -12,7 +12,7 @@ import {
 
 export default class TextLinkPanel extends Component {
   componentDidMount() {
-    const { anchorTarget, relValue, getEditorState, theme, t } = this.props;
+    const { anchorTarget, relValue, getEditorState, theme, t, uiSettings } = this.props;
     const linkData = getLinkDataInSelection(getEditorState());
     const { url, target, rel } = linkData || {};
     const targetBlank = target === '_blank';
@@ -30,6 +30,7 @@ export default class TextLinkPanel extends Component {
       onCancel: this.hideLinkPanel,
       onDelete: this.deleteLink,
       onOverrideContent: this.props.onOverrideContent,
+      uiSettings
     };
 
     const LinkPanelContainerWithProps = decorateComponentWithProps(LinkPanelContainer, linkContainerProps);
@@ -73,4 +74,5 @@ TextLinkPanel.propTypes = {
   anchorTarget: PropTypes.string,
   relValue: PropTypes.string,
   t: PropTypes.func,
+  uiSettings: PropTypes.object,
 };

--- a/packages/plugin-link/src/toolbar/createLinkToolbar.js
+++ b/packages/plugin-link/src/toolbar/createLinkToolbar.js
@@ -1,16 +1,30 @@
 import { MODIFIERS, hasLinksInSelection, removeLinksInSelection, EditorModals, getModalStyles } from 'wix-rich-content-common';
 import TextLinkButton from './TextLinkButton';
 
-const openLinkModal = (helpers, isMobile, anchorTarget, relValue, t, theme, getEditorState, setEditorState) => {
+const openLinkModal = ({ helpers, isMobile, anchorTarget, relValue, t, theme, getEditorState, setEditorState, uiSettings }) => {
   const modalStyles = getModalStyles({ fullScreen: false });
   if (helpers && helpers.openModal) {
-    const modalProps = { helpers, modalStyles, isMobile, getEditorState, setEditorState, t, theme, anchorTarget,
-      relValue, modalName: EditorModals.MOBILE_TEXT_LINK_MODAL, hidePopup: helpers.closeModal };
+    const modalProps = {
+      helpers,
+      modalStyles,
+      isMobile,
+      getEditorState,
+      setEditorState,
+      t,
+      theme,
+      anchorTarget,
+      relValue,
+      modalName: EditorModals.MOBILE_TEXT_LINK_MODAL,
+      hidePopup: helpers.closeModal,
+      uiSettings,
+    };
     helpers.openModal(modalProps);
+  } else {
+    console.error('Link plugin: failed to display Link modal dialog since helpers.openModal is not defined'); // eslint-disable-line no-console
   }
 };
 
-export default ({ helpers, isMobile, anchorTarget, relValue, t, theme, getEditorState, setEditorState }) => ({
+export default config => ({
   TextButtonMapper: () => ({
     Link: {
       component: TextLinkButton,
@@ -26,7 +40,7 @@ export default ({ helpers, isMobile, anchorTarget, relValue, t, theme, getEditor
           if (hasLinksInSelection(editorState)) {
             return removeLinksInSelection(editorState);
           } else {
-            openLinkModal(helpers, isMobile, anchorTarget, relValue, t, theme, getEditorState, setEditorState);
+            openLinkModal(config);
           }
         }
       }]

--- a/packages/plugin-mentions/src/createMentionsPlugin.js
+++ b/packages/plugin-mentions/src/createMentionsPlugin.js
@@ -29,18 +29,9 @@ const defaultSettings = {
 
 const createExternalMentionsPlugin = (config = {}) => {
   const type = EXTERNAL_MENTIONS_TYPE;
-  const {
-    decorator,
-    helpers,
-    theme,
-    isMobile,
-    t,
-    anchorTarget,
-    relValue,
-    mentions = {},
-  } = config;
+  const { theme, [type]: mentionSettings = {}, ...rest } = config;
   const styles = mergeStyles({ styles: Styles, theme });
-  const settings = Object.assign({}, defaultSettings, mentions);
+  const settings = Object.assign({}, defaultSettings, mentionSettings);
 
   const plugin = createMentionPlugin({
     mentionComponent: decorateComponentWithProps(MentionComponent, { settings, styles }),
@@ -59,15 +50,11 @@ const createExternalMentionsPlugin = (config = {}) => {
 
   return createBasePlugin(
     {
-      decorator,
       theme,
       type,
-      helpers,
-      isMobile,
-      anchorTarget,
       inlineModals,
-      relValue,
-      t,
+      settings,
+      ...rest
     },
     plugin,
   );

--- a/packages/plugin-video/src/createVideoPlugin.js
+++ b/packages/plugin-video/src/createVideoPlugin.js
@@ -4,13 +4,11 @@ import { VIDEO_TYPE, VIDEO_TYPE_LEGACY } from './types';
 import { createBasePlugin } from 'wix-rich-content-common';
 
 const createVideoPlugin = (config = {}) => {
-  const { decorator, helpers, theme, t, isMobile, anchorTarget, relValue, video: settings } = config;
+  const type = VIDEO_TYPE;
+  const { helpers, t, [type]: settings = {}, ...rest } = config;
 
   return createBasePlugin({
     component: Component,
-    decorator,
-    settings,
-    theme,
     type: VIDEO_TYPE,
     legacyType: VIDEO_TYPE_LEGACY,
     toolbar: createToolbar({
@@ -18,10 +16,9 @@ const createVideoPlugin = (config = {}) => {
       t,
     }),
     helpers,
-    isMobile,
-    anchorTarget,
-    relValue,
+    settings,
     t,
+    ...rest
   });
 };
 


### PR DESCRIPTION
**new feature:**
`config.uiSettings` exposes `blankTargetToggleVisibilityFn` and `nofollowRelToggleVisibilityFn` functions that define link option checkboxes visibility.

**refactoring:**
* `config` plugin-specific section keys are standardized -- now the plugin types should be used as keys (**breaking change**)
* all the `createPlugin` functions: unused config properties implicitly passed as `...rest`


