### PR TITLE
Fix link issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
   - [#171](https://github.com/wix-incubator/rich-content/pull/171) SEO demand: render list item content wrapped in <p> tags
 - `viewer`
   - [#171](https://github.com/wix-incubator/rich-content/pull/171) SEO demand: render list item content wrapped in <p> tags
-  - plugin rendering: redundant whitespaces removed
+  - [#175](https://github.com/wix-incubator/rich-content/pull/175) plugin rendering: redundant whitespaces removed
 - `link`
-  - `LinkParseStrategy` omits parsed range if it matches an entity range (link duplicates issue)
+  - [#175](https://github.com/wix-incubator/rich-content/pull/175) `LinkParseStrategy` omits parsed range if it matches an entity range (link duplicates issue)
 
 <br/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   - [#171](https://github.com/wix-incubator/rich-content/pull/171) SEO demand: render list item content wrapped in <p> tags
 - `viewer`
   - [#171](https://github.com/wix-incubator/rich-content/pull/171) SEO demand: render list item content wrapped in <p> tags
+  - plugin rendering: redundant whitespaces removed
+- `link`
+  - `LinkParseStrategy` omits parsed range if it matches an entity range (link duplicates issue)
 
 <br/>
 

--- a/packages/plugin-link/src/LinkParseStrategy.js
+++ b/packages/plugin-link/src/LinkParseStrategy.js
@@ -1,14 +1,27 @@
 import { getUrlMatches } from 'wix-rich-content-common';
 
 export const LinkParseStrategy = (contentBlock, callback) => {
+
   const text = contentBlock.getText();
   if (!text) {
     return [];
   }
 
-  const linkMatches = getUrlMatches(text);
+  let linkMatches = getUrlMatches(text);
   if (!linkMatches || linkMatches.length === 0) {
     return [];
+  }
+
+  // NOTE: this code assumes that if there's an entity range that perfectly matches the parsed link range =>
+  // this entity range is LINK typed range, and it should be ignored by this decorator. Currently, there's no way
+  // to get the actual range type within this decorator.
+  if (contentBlock.entityRanges) {
+    contentBlock.entityRanges.forEach(({ offset, length }) => {
+      const entityRangeStart = offset;
+      const entityRangeEnd = offset + length;
+      linkMatches = linkMatches.filter(({ index, lastIndex }) =>
+        !(index === entityRangeStart && lastIndex === entityRangeEnd));
+    });
   }
 
   linkMatches.forEach(({ index, lastIndex }) => {

--- a/packages/viewer/src/PluginsViewer.jsx
+++ b/packages/viewer/src/PluginsViewer.jsx
@@ -51,7 +51,7 @@ const AtomicBlock = ({ type, typeMap, componentData, children, theme, isMobile, 
           {renderLink(componentData, anchorTarget, relValue)}
         </div>);
     } else {
-      return <Component componentData={componentData} theme={theme} settings={settings} isMobile={isMobile} {...props}> {children} </Component>;
+      return <Component componentData={componentData} theme={theme} settings={settings} isMobile={isMobile} {...props}>{children}</Component>;
     }
   }
   return null;


### PR DESCRIPTION
- [viewer] plugin rendering: redundant whitespaces removed
- [link] `LinkParseStrategy` omits parsed range if it matches an entity range (link duplicates issue)
fixes #165 
fixes #166 