### PR TITLE
Editor example scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ## [Unreleased]
 
+### :bug: Bug Fix
+
+- `examples`
+  - [#215](https://github.com/wix-incubator/rich-content/pull/215) [editor](https://github.com/wix-incubator/rich-content/tree/master/examples/editor) Re-enable document scrolling after closing a modal when cliking outside + Prevent flyOut modals from jumping up when opening
+  
 <br/>
 
 ## 1.7.6 (Dec 27, 2018)

--- a/examples/editor/src/App.jsx
+++ b/examples/editor/src/App.jsx
@@ -86,7 +86,6 @@ class App extends Component {
       openModal: data => {
         const { modalStyles, ...modalProps } = data;
         try {
-          document.body.style.overflow = document.documentElement.style.overflow = 'hidden';
           document.documentElement.style.height = '100%';
           document.documentElement.style.position = 'relative';
         } catch (e) {
@@ -100,7 +99,6 @@ class App extends Component {
       },
       closeModal: () => {
         try {
-          document.body.style.overflow = document.documentElement.style.overflow = 'auto';
           document.documentElement.style.height = 'initial';
           document.documentElement.style.position = 'initial';
         } catch (e) {

--- a/examples/editor/src/App.jsx
+++ b/examples/editor/src/App.jsx
@@ -145,6 +145,12 @@ class App extends Component {
   };
 
   closeModal = () => {
+    try {
+      document.documentElement.style.height = 'initial';
+      document.documentElement.style.position = 'initial';
+    } catch (e) {
+      console.warn('Cannot change document styles', e);
+    }
     this.setState({
       showModal: false,
       modalContent: null,

--- a/examples/editor/src/App.jsx
+++ b/examples/editor/src/App.jsx
@@ -108,6 +108,7 @@ class App extends Component {
           showModal: false,
           modalProps: null,
           modalStyles: null,
+          modalContent: null
         });
       },
     };
@@ -141,19 +142,6 @@ class App extends Component {
     this.setState({
       lastSave: new Date(),
       editorState,
-    });
-  };
-
-  closeModal = () => {
-    try {
-      document.documentElement.style.height = 'initial';
-      document.documentElement.style.position = 'initial';
-    } catch (e) {
-      console.warn('Cannot change document styles', e);
-    }
-    this.setState({
-      showModal: false,
-      modalContent: null,
     });
   };
 
@@ -263,7 +251,7 @@ class App extends Component {
               contentLabel="External Modal Example"
               style={modalStyles}
               role="dialog"
-              onRequestClose={this.closeModal}
+              onRequestClose={this.helpers.closeModal}
             >
               {this.state.showModal &&
               <RichContentEditorModal

--- a/examples/editor/src/Plugins.jsx
+++ b/examples/editor/src/Plugins.jsx
@@ -19,7 +19,6 @@ import 'wix-rich-content-plugin-hashtag/dist/styles.min.css';
 import 'wix-rich-content-plugin-link/dist/styles.min.css';
 import 'wix-rich-content-plugin-mentions/dist/styles.min.css';
 import 'wix-rich-content-plugin-video/dist/styles.min.css';
-import 'wix-rich-content-plugin-code-block/dist/styles.min.css';
 import 'wix-rich-content-plugin-sound-cloud/dist/styles.min.css';
 import 'wix-rich-content-plugin-giphy/dist/styles.min.css';
 


### PR DESCRIPTION
- closeModal function should re-enable default document behavior (re-enable scrolling) same as closeModal helper 
- when a modal opens it sets overflow to hidden , no need to validate document overflow , It was causing flyOut modals to jump up when opening 
 