### PR TITLE
Vimeo - urls not prefixed with http[s] didn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,17 @@
 
 ## [Unreleased]
 
-
 ### :house: Internal
 
 - `general`
   - [#239](https://github.com/wix-incubator/rich-content/pull/239) prettier formatter
 - `common`
   - validate plugin schema only in development
+
+### :bug: Bug Fix
+
+- `video`
+  - [#238](https://github.com/wix-incubator/rich-content/pull/238) Vimeo - urls not prefixed with http[s] didn't work
 
 <hr/>
 

--- a/packages/plugin-video/src/video-viewer.jsx
+++ b/packages/plugin-video/src/video-viewer.jsx
@@ -21,15 +21,14 @@ class VideoViewer extends Component {
     }
   }
 
+  normalizeUrl = url => (url.toLowerCase().indexOf('vimeo') === 0 ? 'https://' + url : url); //vimeo player needs urls prefixed with http[s]
+
   render() {
     const { componentData, theme, settings, isMobile, ...rest } = this.props; // eslint-disable-line no-unused-vars
-    return (
-      <ReactPlayer
-        className={classNames(this.styles.video_player)}
-        url={getVideoSrc(componentData.src, settings)}
-        {...rest}
-      />
-    );
+
+    const url = this.normalizeUrl(getVideoSrc(componentData.src, settings));
+
+    return <ReactPlayer className={classNames(this.styles.video_player)} url={url} {...rest} />;
   }
 }
 


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
