### PR TITLE
[viewer] avoid crashing app if img or video plugins fail

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,18 @@
 {
-  "extends": ["wix/react", "plugin:jsx-a11y/strict"],
+  "extends": [
+    "wix/react",
+    "plugin:jsx-a11y/strict"
+  ],
   "env": {
     "browser": true,
     "node": true
   },
-  "plugins": ["lodash", "fp", "jsx-a11y"],
+  "plugins": [
+    "lodash",
+    "fp",
+    "jsx-a11y",
+    "prettier"
+  ],
   "settings": {
     "react": {
       "version": "15.5.4"
@@ -53,6 +61,7 @@
     "mocha/no-pending-tests": "error",
     "no-param-reassign": "warn",
     "jsx-a11y/label-has-for": "off",
-    "jsx-a11y/aria-proptypes": "off"
+    "jsx-a11y/aria-proptypes": "off",
+    "prettier/prettier": "warn"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,7 @@
         "allowTemplateLiterals": true
       }
     ],
-    "react/jsx-quotes": ["warn", "prefer-single"],
+    "jsx-quotes": ["warn", "prefer-single"],
     "react/jsx-closing-tag-location": "error",
     "react/jsx-closing-bracket-location": [
       1,

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
         "allowTemplateLiterals": true
       }
     ],
+    "react/jsx-quotes": ["warn", "prefer-single"],
     "react/jsx-closing-tag-location": "error",
     "react/jsx-closing-bracket-location": [
       1,

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "davidanson.vscode-markdownlint",
     "yzhang.markdown-all-in-one",
     "mgmcdermott.vscode-language-babel",
-    "flowtype.flow-for-vscode",
-    "gcazaciuc.vscode-flow-ide",
+    "esbenp.prettier-vscode",
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "editor.formatOnSave": true,
+  "prettier.eslintIntegration": true,
+  "prettier.requireConfig": true,
+  "prettier.disableLanguages": [
+    "vue",
+    "css",
+    "scss",
+    "sass"
+  ],
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### :house: Internal
 
+- `general`
+  - [#239](https://github.com/wix-incubator/rich-content/pull/239) prettier formatter
 - `common`
   - validate plugin schema only in development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ## [Unreleased]
 
+
+### :house: Internal
+
+- `common`
+  - validate plugin schema only in development
+
 <hr/>
 
 ## Video Plugin 1.6.0 (Jan 20, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## [Unreleased]
 
+### :bug: Bug Fix
+
+- `viewer`
+  - render empty container div when there is no content
 
 ### :house: Internal
 

--- a/examples/editor/config/webpack.common.js
+++ b/examples/editor/config/webpack.common.js
@@ -24,6 +24,8 @@ module.exports = env => ({
     symlinks: false,
     alias: {
       'draft-js': path.resolve(__dirname, '..', '..', '..', 'node_modules', '@wix', 'draft-js'),
+      '@wix/draft-js': path.resolve(__dirname, '..', '..', '..', 'node_modules', '@wix', 'draft-js'),
+      'wix-rich-content-common': path.resolve(__dirname, '..', '..', '..', 'packages', 'common'),
     },
   },
   module: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -312,7 +311,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -819,7 +817,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
 			"integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.12.0"
 			}
@@ -2340,6 +2337,17 @@
 				"@xtuc/long": "4.2.1"
 			}
 		},
+		"@wix/draft-js": {
+			"version": "0.10.272",
+			"resolved": "https://registry.npmjs.org/@wix/draft-js/-/draft-js-0.10.272.tgz",
+			"integrity": "sha512-D0pRzS8J6xBg057u3SN0ec46NzT2C/y240LdSdHH1XY9im1F6WFeGOSDSfXWPjEyjljhFJyL71b8FU1r9qDsBQ==",
+			"requires": {
+				"fbjs": "^0.8.15",
+				"immutable": "~3.7.4",
+				"object-assign": "^4.1.0",
+				"wnpm-ci": "^7.0.1"
+			}
+		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -2365,8 +2373,7 @@
 		"abab": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
-			"dev": true
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -2404,8 +2411,7 @@
 		"acorn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-			"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
-			"dev": true
+			"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
 		},
 		"acorn-dynamic-import": {
 			"version": "3.0.0",
@@ -2428,7 +2434,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
 			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
-			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
@@ -2454,8 +2459,12 @@
 		"acorn-walk": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
-			"dev": true
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
+		},
+		"add-px-to-style": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/add-px-to-style/-/add-px-to-style-1.0.0.tgz",
+			"integrity": "sha1-0ME1RB+oAUqBN5BFMQlvZ/KPJjo="
 		},
 		"agent-base": {
 			"version": "4.2.1",
@@ -2479,7 +2488,6 @@
 			"version": "6.7.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
 			"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
-			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2520,8 +2528,7 @@
 		"ansi-escapes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-			"dev": true
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-html": {
 			"version": "0.0.7",
@@ -2532,14 +2539,12 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -2548,10 +2553,17 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"requires": {
+				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"aproba": {
@@ -2574,7 +2586,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -2592,20 +2603,17 @@
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-			"dev": true
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
 			"version": "1.0.0",
@@ -2616,8 +2624,7 @@
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-			"dev": true
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"array-find-index": {
 			"version": "1.0.2",
@@ -2665,8 +2672,7 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-			"dev": true
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"array.prototype.find": {
 			"version": "2.0.4",
@@ -2681,20 +2687,17 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -2739,14 +2742,12 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
 		"ast-types-flow": {
 			"version": "0.0.7",
@@ -2754,11 +2755,15 @@
 			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
 			"dev": true
 		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+		},
 		"async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
 			}
@@ -2778,20 +2783,17 @@
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-			"dev": true
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"dev": true
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"autoprefixer": {
 			"version": "6.7.7",
@@ -2822,14 +2824,12 @@
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
 		"axobject-query": {
 			"version": "2.0.2",
@@ -2844,7 +2844,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
@@ -2854,14 +2853,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -2873,14 +2870,12 @@
 				"js-tokens": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -2906,7 +2901,6 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -2921,8 +2915,7 @@
 				"jsesc": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-					"dev": true
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 				}
 			}
 		},
@@ -2941,7 +2934,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -2951,7 +2943,6 @@
 			"version": "23.6.0",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
 			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-istanbul": "^4.1.6",
 				"babel-preset-jest": "^23.2.0"
@@ -2973,7 +2964,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2982,7 +2972,6 @@
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
 				"find-up": "^2.1.0",
@@ -2993,8 +2982,7 @@
 		"babel-plugin-jest-hoist": {
 			"version": "23.2.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-			"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
-			"dev": true
+			"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
 		},
 		"babel-plugin-react-svg": {
 			"version": "2.1.0",
@@ -3017,8 +3005,7 @@
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-transform-flow-strip-types": {
 			"version": "6.22.0",
@@ -3093,7 +3080,6 @@
 			"version": "23.2.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
 			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-jest-hoist": "^23.2.0",
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
@@ -3117,7 +3103,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
 			"requires": {
 				"babel-core": "^6.26.0",
 				"babel-runtime": "^6.26.0",
@@ -3132,7 +3117,6 @@
 					"version": "6.26.3",
 					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-					"dev": true,
 					"requires": {
 						"babel-code-frame": "^6.26.0",
 						"babel-generator": "^6.26.0",
@@ -3158,14 +3142,12 @@
 				"json5": {
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-					"dev": true
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-					"dev": true
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 				}
 			}
 		},
@@ -3173,7 +3155,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -3182,8 +3163,7 @@
 				"regenerator-runtime": {
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-					"dev": true
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 				}
 			}
 		},
@@ -3191,7 +3171,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-traverse": "^6.26.0",
@@ -3204,7 +3183,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-messages": "^6.23.0",
@@ -3220,8 +3198,7 @@
 				"globals": {
 					"version": "9.18.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-					"dev": true
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 				}
 			}
 		},
@@ -3229,7 +3206,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"esutils": "^2.0.2",
@@ -3240,28 +3216,24 @@
 				"to-fast-properties": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-					"dev": true
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 				}
 			}
 		},
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -3276,7 +3248,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -3285,7 +3256,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3294,7 +3264,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3303,7 +3272,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -3328,7 +3296,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -3486,8 +3453,7 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-			"dev": true
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"boom": {
 			"version": "4.3.1",
@@ -3498,11 +3464,15 @@
 				"hoek": "4.x.x"
 			}
 		},
+		"bowser": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+			"integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3512,7 +3482,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.1.0",
 				"array-unique": "^0.3.2",
@@ -3530,7 +3499,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -3546,8 +3514,27 @@
 		"browser-process-hrtime": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
-			"dev": true
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
+		},
+		"browser-resolve": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+				}
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
@@ -3642,6 +3629,14 @@
 				"node-releases": "^1.1.3"
 			}
 		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"requires": {
+				"node-int64": "^0.4.0"
+			}
+		},
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
@@ -3668,8 +3663,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -3686,8 +3680,7 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
@@ -3744,7 +3737,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -3784,8 +3776,7 @@
 		"callsites": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-			"dev": true
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 		},
 		"camel-case": {
 			"version": "3.0.0",
@@ -3826,7 +3817,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
 			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-			"dev": true,
 			"requires": {
 				"browserslist": "^1.3.6",
 				"caniuse-db": "^1.0.30000529",
@@ -3838,7 +3828,6 @@
 					"version": "1.7.7",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"dev": true,
 					"requires": {
 						"caniuse-db": "^1.0.30000639",
 						"electron-to-chromium": "^1.2.7"
@@ -3849,8 +3838,7 @@
 		"caniuse-db": {
 			"version": "1.0.30000928",
 			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000928.tgz",
-			"integrity": "sha512-nAoeTspAEzLjqGSeibzM09WojORi08faeOOI5GBmFWC3/brydovb9lYJWM+p48rEQsdevfpufK58gPiDtwOWKw==",
-			"dev": true
+			"integrity": "sha512-nAoeTspAEzLjqGSeibzM09WojORi08faeOOI5GBmFWC3/brydovb9lYJWM+p48rEQsdevfpufK58gPiDtwOWKw=="
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000928",
@@ -3858,17 +3846,23 @@
 			"integrity": "sha512-aSpMWRXL6ZXNnzm8hgE4QDLibG5pVJ2Ujzsuj3icazlIkxXkPXtL+BWnMx6FBkWmkZgBHGUxPZQvrbRw2ZTxhg==",
 			"dev": true
 		},
+		"capture-exit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"requires": {
+				"rsvp": "^3.3.3"
+			}
+		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -3886,6 +3880,51 @@
 			"resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
 			"integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
 			"dev": true
+		},
+		"cheerio": {
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+			"integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+			"requires": {
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.0",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash.assignin": "^4.0.9",
+				"lodash.bind": "^4.1.4",
+				"lodash.defaults": "^4.0.1",
+				"lodash.filter": "^4.4.0",
+				"lodash.flatten": "^4.2.0",
+				"lodash.foreach": "^4.3.0",
+				"lodash.map": "^4.4.0",
+				"lodash.merge": "^4.4.0",
+				"lodash.pick": "^4.2.1",
+				"lodash.reduce": "^4.4.0",
+				"lodash.reject": "^4.4.0",
+				"lodash.some": "^4.4.0"
+			},
+			"dependencies": {
+				"css-select": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+					"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+					"requires": {
+						"boolbase": "~1.0.0",
+						"css-what": "2.1",
+						"domutils": "1.5.1",
+						"nth-check": "~1.0.1"
+					}
+				},
+				"domutils": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+					"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+					"requires": {
+						"dom-serializer": "0",
+						"domelementtype": "1"
+					}
+				}
+			}
 		},
 		"chokidar": {
 			"version": "2.0.4",
@@ -3985,7 +4024,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -3997,12 +4035,16 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
+		},
+		"classnames": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
@@ -4037,6 +4079,17 @@
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
 			"dev": true
+		},
+		"clipboard": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+			"integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+			"optional": true,
+			"requires": {
+				"good-listener": "^1.2.2",
+				"select": "^1.1.2",
+				"tiny-emitter": "^2.0.0"
+			}
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -4092,8 +4145,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"coa": {
 			"version": "2.0.2",
@@ -4109,14 +4161,12 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -4137,7 +4187,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -4145,8 +4194,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
 			"version": "0.3.0",
@@ -4188,7 +4236,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
 			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -4229,8 +4276,7 @@
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-			"dev": true
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"compressible": {
 			"version": "2.0.15",
@@ -4259,8 +4305,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -4327,6 +4372,11 @@
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
+		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
 		},
 		"content-disposition": {
 			"version": "0.5.2",
@@ -4496,7 +4546,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -4530,8 +4579,7 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"copy-webpack-plugin": {
 			"version": "4.6.0",
@@ -4574,14 +4622,12 @@
 		"core-js": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
-			"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g==",
-			"dev": true
+			"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "5.0.7",
@@ -4685,7 +4731,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -4736,6 +4781,37 @@
 			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
 			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
 			"dev": true
+		},
+		"css-in-js-utils": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+			"integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+			"requires": {
+				"hyphenate-style-name": "^1.0.2",
+				"isobject": "^3.0.1"
+			}
+		},
+		"css-keyframer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-keyframer/-/css-keyframer-1.0.1.tgz",
+			"integrity": "sha1-RBAX8+LWjJKnpQuLZ2a8ucjvCQ8=",
+			"requires": {
+				"exenv": "^1.2.1",
+				"hyphenate-style-name": "^1.0.2",
+				"inline-style-prefixer": "^2.0.5",
+				"is-plain-object": "^2.0.1"
+			},
+			"dependencies": {
+				"inline-style-prefixer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
+					"integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
+					"requires": {
+						"bowser": "^1.0.0",
+						"hyphenate-style-name": "^1.0.1"
+					}
+				}
+			}
 		},
 		"css-loader": {
 			"version": "0.28.11",
@@ -4919,8 +4995,7 @@
 		"css-what": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
-			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
-			"dev": true
+			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
 		},
 		"cssesc": {
 			"version": "0.1.0",
@@ -4992,14 +5067,12 @@
 		"cssom": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
-			"dev": true
+			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
 		},
 		"cssstyle": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
 			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
-			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
 			}
@@ -5050,7 +5123,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -5065,7 +5137,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
@@ -5088,7 +5159,6 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -5102,8 +5172,7 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
@@ -5126,8 +5195,12 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"decorate-component-with-props": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/decorate-component-with-props/-/decorate-component-with-props-1.1.0.tgz",
+			"integrity": "sha512-tTYQojixN64yK3/WBODMfvss/zbmyUx9HQXhzSxZiSiofeekVeRyyuToy9BCiTMrVEIKWxTcla2t3y5qdaUF7Q=="
 		},
 		"dedent": {
 			"version": "0.7.0",
@@ -5141,11 +5214,20 @@
 			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
 			"dev": true
 		},
+		"deep-freeze": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+			"integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ="
+		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"deepmerge": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+			"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
 		},
 		"default-gateway": {
 			"version": "2.7.2",
@@ -5193,6 +5275,14 @@
 				}
 			}
 		},
+		"default-require-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"requires": {
+				"strip-bom": "^2.0.0"
+			}
+		},
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -5215,7 +5305,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -5224,7 +5313,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -5234,7 +5322,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5243,7 +5330,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5252,7 +5338,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -5313,8 +5398,13 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"delegate": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+			"optional": true
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -5354,10 +5444,14 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
 		},
 		"detect-node": {
 			"version": "2.0.4",
@@ -5374,6 +5468,11 @@
 				"asap": "^2.0.0",
 				"wrappy": "1"
 			}
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -5412,6 +5511,11 @@
 				}
 			}
 		},
+		"direction": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.2.tgz",
+			"integrity": "sha512-hSKoz5FBn+zhP9vWKkVQaaxnRDg3/MoPdcg2au54HIUDR8MrP8Ah1jXSJwCXel6SV3Afh5DSzc8Uqv2r1UoQwQ=="
+		},
 		"dns-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -5446,11 +5550,20 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"dom-css": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/dom-css/-/dom-css-2.1.0.tgz",
+			"integrity": "sha1-/bwtWgFdCj4YcuEUcrvQ57nmogI=",
+			"requires": {
+				"add-px-to-style": "1.0.0",
+				"prefix-style": "2.0.1",
+				"to-camel-case": "1.0.0"
+			}
+		},
 		"dom-serializer": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-			"dev": true,
 			"requires": {
 				"domelementtype": "~1.1.1",
 				"entities": "~1.1.1"
@@ -5459,8 +5572,7 @@
 				"domelementtype": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-					"dev": true
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
 				}
 			}
 		},
@@ -5473,23 +5585,28 @@
 		"domelementtype": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-			"dev": true
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-			"dev": true,
 			"requires": {
 				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"domhandler": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"requires": {
+				"domelementtype": "1"
 			}
 		},
 		"domutils": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
 			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-			"dev": true,
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
@@ -5502,6 +5619,96 @@
 			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
+			}
+		},
+		"draft-js-code": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/draft-js-code/-/draft-js-code-0.3.0.tgz",
+			"integrity": "sha512-e/Rblaj1FvYzvQK45QHt8qAl5lBLFSHWPzNrF8Avv/8Bx0ZtPHD8ykCdazM2NjTvinZmPJ5dLoRHphgFQycasg==",
+			"requires": {
+				"detect-indent": "^4.0.0",
+				"detect-newline": "^2.1.0",
+				"ends-with": "^0.2.0",
+				"immutable": "3.x"
+			}
+		},
+		"draft-js-drag-n-drop-plugin": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/draft-js-drag-n-drop-plugin/-/draft-js-drag-n-drop-plugin-2.0.3.tgz",
+			"integrity": "sha512-sEM6nmDb4/vk7Ol0brGDxJmaBBu1Nf1Pl6GzZuDCAOMIfjZaLGnEf++SrtfA/1PoiMOhF2FN7y3i7QiuRXqOLg==",
+			"requires": {
+				"decorate-component-with-props": "^1.0.2",
+				"find-with-regex": "^1.1.3",
+				"immutable": "~3.7.4",
+				"prop-types": "^15.5.8",
+				"union-class-names": "^1.0.0"
+			}
+		},
+		"draft-js-emoji-plugin": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/draft-js-emoji-plugin/-/draft-js-emoji-plugin-2.1.1.tgz",
+			"integrity": "sha512-qVSZ+V/AD2KBLuIM91iu6cC5Tl31T8/tHlwYm1oZpnPOkIlnnK5dX3InxCL4zn5cVtelKBCJbC1xteeDYXYlqA==",
+			"requires": {
+				"decorate-component-with-props": "^1.1.0",
+				"emojione": "^2.2.7",
+				"find-with-regex": "^1.1.3",
+				"immutable": "~3.7.4",
+				"lodash.keys": "^4.2.0",
+				"prop-types": "^15.5.8",
+				"react-custom-scrollbars": "^4.2.0",
+				"react-icons": "^2.2.6",
+				"to-style": "^1.3.3",
+				"union-class-names": "^1.0.0"
+			}
+		},
+		"draft-js-focus-plugin": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/draft-js-focus-plugin/-/draft-js-focus-plugin-2.2.0.tgz",
+			"integrity": "sha512-Jnvhmn1oAI/QgRXvU8gAtpevPZh6NIcdpsbzvxxZ8eCT/McRMeru8N5DuVtYmTbd/BItRb7s7CcUWoM804wVmw==",
+			"requires": {
+				"decorate-component-with-props": "^1.0.2",
+				"find-with-regex": "^1.1.3",
+				"immutable": "~3.7.4",
+				"prop-types": "^15.5.8",
+				"union-class-names": "^1.0.0"
+			}
+		},
+		"draft-js-linkify-plugin": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/draft-js-linkify-plugin/-/draft-js-linkify-plugin-2.0.1.tgz",
+			"integrity": "sha512-dCqlAUCMy+qkqx1dvHgCb8NBDZprcMkPO4Hnpj4Jo0AU4q2J/Uat6zo2Z62NdAZRkftqTRv0arMWqikTGQb1xg==",
+			"requires": {
+				"decorate-component-with-props": "^1.0.2",
+				"immutable": "~3.7.4",
+				"linkify-it": "^2.0.3",
+				"prop-types": "^15.5.8",
+				"tlds": "^1.189.0",
+				"union-class-names": "^1.0.0"
+			}
+		},
+		"draft-js-mention-plugin": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/draft-js-mention-plugin/-/draft-js-mention-plugin-3.1.3.tgz",
+			"integrity": "sha512-L9pMZtSaMouLUKhIFVqGGVV38/z/2RtcGb5c27GMVU9MYqfwXAl4zBOP+Fb8TN7Gj1OQd6BpQ+jodoWwm8wQ3Q==",
+			"requires": {
+				"decorate-component-with-props": "^1.0.2",
+				"find-with-regex": "^1.1.3",
+				"immutable": "~3.7.4",
+				"lodash.escaperegexp": "^4.1.2",
+				"prop-types": "^15.5.8",
+				"union-class-names": "^1.0.0"
+			}
+		},
+		"draft-js-plugins-editor": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/draft-js-plugins-editor/-/draft-js-plugins-editor-2.1.1.tgz",
+			"integrity": "sha512-fKGe71irNvFHJ5L/lUrh+3vPkBNq0de6x+cgiZUJ9zQERc5KPBtGXIFiarLFVHyrRTCPq+K6xmgfFSAERaFHPw==",
+			"requires": {
+				"decorate-component-with-props": "^1.0.2",
+				"find-with-regex": "^1.1.3",
+				"immutable": "~3.7.4",
+				"prop-types": "^15.5.8",
+				"union-class-names": "^1.0.0"
 			}
 		},
 		"du": {
@@ -5543,7 +5750,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -5564,8 +5770,7 @@
 		"electron-to-chromium": {
 			"version": "1.3.103",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz",
-			"integrity": "sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ==",
-			"dev": true
+			"integrity": "sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -5588,6 +5793,11 @@
 			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
 			"dev": true
 		},
+		"emojione": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/emojione/-/emojione-2.2.7.tgz",
+			"integrity": "sha1-RkV89rmy+NoTroouTlR94G7hXpY="
+		},
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -5604,7 +5814,6 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -5617,6 +5826,11 @@
 			"requires": {
 				"once": "^1.4.0"
 			}
+		},
+		"ends-with": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
+			"integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o="
 		},
 		"enhanced-resolve": {
 			"version": "4.1.0",
@@ -5632,8 +5846,24 @@
 		"entities": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-			"dev": true
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+		},
+		"enzyme": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
+			"integrity": "sha1-B9XOaRJBJA+4F78sSxjW5TAkDfY=",
+			"requires": {
+				"cheerio": "^0.22.0",
+				"function.prototype.name": "^1.0.0",
+				"is-subset": "^0.1.1",
+				"lodash": "^4.17.4",
+				"object-is": "^1.0.1",
+				"object.assign": "^4.0.4",
+				"object.entries": "^1.0.4",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.5.10",
+				"uuid": "^3.0.1"
+			}
 		},
 		"err-code": {
 			"version": "1.1.2",
@@ -5654,7 +5884,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -5663,7 +5892,6 @@
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
 			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
@@ -5677,7 +5905,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
 			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -5687,8 +5914,7 @@
 		"es6-promise": {
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-			"integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
-			"dev": true
+			"integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
@@ -5708,14 +5934,12 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
 			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
-			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
@@ -5727,14 +5951,12 @@
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -5906,6 +6128,39 @@
 			"integrity": "sha1-eASUKYxFFjSAunyAXxME1AiWTR0=",
 			"dev": true
 		},
+		"eslint-import-resolver-lerna": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-lerna/-/eslint-import-resolver-lerna-1.0.0.tgz",
+			"integrity": "sha512-0srStLw9u9jYbYdkrx/LdSsnLeumrUfcTp8b/eoqCYrSAFRYaMhON5TimXJhLgyCyqrU26gO44HmcU9p/pGmTg=="
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.5.0"
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
+			"integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+			"requires": {
+				"debug": "^2.6.8",
+				"pkg-dir": "^2.0.0"
+			},
+			"dependencies": {
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				}
+			}
+		},
 		"eslint-plugin-babel": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
@@ -5922,6 +6177,85 @@
 				"eslint-ast-utils": "^1.0.0",
 				"lodash": "^4.13.1",
 				"req-all": "^0.1.0"
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
+			"integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+			"requires": {
+				"builtin-modules": "^1.1.1",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.8",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.1",
+				"eslint-module-utils": "^2.1.1",
+				"has": "^1.0.1",
+				"lodash.cond": "^4.3.0",
+				"minimatch": "^3.0.3",
+				"read-pkg-up": "^2.0.0"
+			},
+			"dependencies": {
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				}
 			}
 		},
 		"eslint-plugin-jasmine": {
@@ -5973,6 +6307,15 @@
 			"dev": true,
 			"requires": {
 				"ramda": "^0.25.0"
+			}
+		},
+		"eslint-plugin-prettier": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
+			"integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
+			"dev": true,
+			"requires": {
+				"prettier-linter-helpers": "^1.0.0"
 			}
 		},
 		"eslint-plugin-react": {
@@ -6055,8 +6398,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
 			"version": "1.0.1",
@@ -6079,8 +6421,7 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-			"dev": true
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"estree-walker": {
 			"version": "0.5.2",
@@ -6091,8 +6432,7 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -6131,6 +6471,14 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
+		"exec-sh": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+			"requires": {
+				"merge": "^1.2.0"
+			}
+		},
 		"execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -6161,11 +6509,20 @@
 				}
 			}
 		},
+		"exenv": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+			"integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.3.3",
 				"define-property": "^0.2.5",
@@ -6180,7 +6537,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -6189,7 +6545,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -6200,7 +6555,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
 			},
@@ -6209,7 +6563,6 @@
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"dev": true,
 					"requires": {
 						"is-number": "^2.1.0",
 						"isobject": "^2.0.0",
@@ -6222,7 +6575,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -6231,7 +6583,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
@@ -6240,7 +6591,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6254,6 +6604,19 @@
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
+			}
+		},
+		"expect": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
+			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"jest-diff": "^23.6.0",
+				"jest-get-type": "^22.1.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-regex-util": "^23.3.0"
 			}
 		},
 		"express": {
@@ -6297,14 +6660,12 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -6314,7 +6675,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -6336,7 +6696,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
 				"define-property": "^1.0.0",
@@ -6352,7 +6711,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -6361,7 +6719,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -6370,7 +6727,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -6379,7 +6735,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -6388,7 +6743,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -6400,8 +6754,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"eyes": {
 			"version": "0.1.8",
@@ -6412,7 +6765,12 @@
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+		},
+		"fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
 			"dev": true
 		},
 		"fast-glob": {
@@ -6432,14 +6790,12 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fastparse": {
 			"version": "1.1.2",
@@ -6454,6 +6810,35 @@
 			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
+			}
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"requires": {
+				"bser": "^2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
 		},
 		"figgy-pudding": {
@@ -6484,8 +6869,16 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"requires": {
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
+			}
 		},
 		"filesize": {
 			"version": "3.6.1",
@@ -6497,7 +6890,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-number": "^3.0.0",
@@ -6509,7 +6901,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -6552,10 +6943,14 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "^2.0.0"
 			}
+		},
+		"find-with-regex": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/find-with-regex/-/find-with-regex-1.1.3.tgz",
+			"integrity": "sha512-zkEVQ1H3PIQL/19ADKt1lCQU4QGM3OneiderUcFgn5EgTm/TnoUh7HxPAwP8w/vXxWSLC6KtpbDQpypJ5+majw=="
 		},
 		"findup-sync": {
 			"version": "2.0.0",
@@ -6608,6 +7003,14 @@
 				"readable-stream": "^2.0.4"
 			}
 		},
+		"focus-trap": {
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-2.4.6.tgz",
+			"integrity": "sha512-vWZTPtBU6pBoyWZDRZJHkXsyP2ZCZBHE3DRVXnSVdQKH/mcDtu9S5Kz8CUDyIqpfZfLEyI9rjKJLnc4Y40BRBg==",
+			"requires": {
+				"tabbable": "^1.0.3"
+			}
+		},
 		"follow-redirects": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
@@ -6631,14 +7034,12 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -6652,14 +7053,12 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -6676,7 +7075,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -6749,14 +7147,12 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
 			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -6766,24 +7162,21 @@
 				"abbrev": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -6793,12 +7186,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -6807,34 +7200,31 @@
 				"chownr": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -6843,25 +7233,21 @@
 				"deep-extend": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -6870,13 +7256,11 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -6892,7 +7276,6 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -6906,13 +7289,11 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": "^2.1.0"
@@ -6921,7 +7302,6 @@
 				"ignore-walk": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -6930,7 +7310,6 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -6940,18 +7319,17 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -6959,13 +7337,12 @@
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -6973,12 +7350,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
-					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -6987,7 +7364,6 @@
 				"minizlib": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -6996,7 +7372,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -7004,13 +7380,11 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^2.1.2",
@@ -7021,7 +7395,6 @@
 				"node-pre-gyp": {
 					"version": "0.10.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -7039,7 +7412,6 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -7049,13 +7421,11 @@
 				"npm-bundled": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -7065,7 +7435,6 @@
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -7077,18 +7446,17 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -7096,19 +7464,16 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -7118,19 +7483,16 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -7142,7 +7504,6 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -7150,7 +7511,6 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -7165,7 +7525,6 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -7174,42 +7533,37 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7219,7 +7573,6 @@
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -7228,7 +7581,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7236,13 +7589,11 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -7257,13 +7608,11 @@
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -7272,12 +7621,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"optional": true
 				}
 			}
 		},
@@ -7318,8 +7667,17 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"function.prototype.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"is-callable": "^1.1.3"
+			}
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
@@ -7447,8 +7805,12 @@
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-			"dev": true
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+		},
+		"get-node-dimensions": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz",
+			"integrity": "sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ=="
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
@@ -7587,16 +7949,25 @@
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
+			}
+		},
+		"giphy-js-sdk-core": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/giphy-js-sdk-core/-/giphy-js-sdk-core-1.0.6.tgz",
+			"integrity": "sha512-WaOm2ZEMSyPzlM+XbiVSDPZiSNfNfCItIeLh9QNglqiSl5fqewjTl7TY9wJT41Q/ORyOekV5rJDe4EIkjLDLFw==",
+			"requires": {
+				"es6-promise": "^4.1.0",
+				"isomorphic-fetch": "^2.2.1",
+				"lodash": "^4.17.4",
+				"promise": "^7.1.1"
 			}
 		},
 		"git-raw-commits": {
@@ -7645,7 +8016,6 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -7659,7 +8029,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
@@ -7669,7 +8038,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^2.0.0"
 					}
@@ -7677,14 +8045,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7793,11 +8159,29 @@
 				"minimatch": "~3.0.2"
 			}
 		},
+		"good-listener": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+			"optional": true,
+			"requires": {
+				"delegate": "^3.1.2"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-			"dev": true
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
 		},
 		"gzip-size": {
 			"version": "5.0.0",
@@ -7881,7 +8265,6 @@
 			"version": "4.0.12",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
 			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
-			"dev": true,
 			"requires": {
 				"async": "^2.5.0",
 				"optimist": "^0.6.1",
@@ -7892,22 +8275,19 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -7917,7 +8297,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -7926,7 +8305,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -7934,14 +8312,12 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-			"dev": true
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -7953,7 +8329,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -7964,7 +8339,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -7974,7 +8348,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8013,6 +8386,11 @@
 				"sntp": "2.x.x"
 			}
 		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -8030,11 +8408,15 @@
 			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
 			"dev": true
 		},
+		"hoist-non-react-statics": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.1"
@@ -8058,8 +8440,7 @@
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-			"dev": true
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
 		},
 		"hpack.js": {
 			"version": "2.1.6",
@@ -8083,7 +8464,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"dev": true,
 			"requires": {
 				"whatwg-encoding": "^1.0.1"
 			}
@@ -8093,6 +8473,39 @@
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
 			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
 			"dev": true
+		},
+		"html-parse-stringify2": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz",
+			"integrity": "sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=",
+			"requires": {
+				"void-elements": "^2.0.1"
+			}
+		},
+		"htmlparser2": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+			"integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+			"requires": {
+				"domelementtype": "^1.3.0",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.0.6"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+					"integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"http-cache-semantics": {
 			"version": "3.8.1",
@@ -8172,7 +8585,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -8301,17 +8713,26 @@
 				}
 			}
 		},
+		"hyphenate-style-name": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+		},
 		"i": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
 			"integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
 			"dev": true
 		},
+		"i18next": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/i18next/-/i18next-10.6.0.tgz",
+			"integrity": "sha1-kP/Z+bxhfzS5oS4DcmD1JERfdoQ="
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -8383,6 +8804,16 @@
 				"minimatch": "^3.0.4"
 			}
 		},
+		"image-client-api": {
+			"version": "1.2218.0",
+			"resolved": "https://registry.npmjs.org/image-client-api/-/image-client-api-1.2218.0.tgz",
+			"integrity": "sha512-swegnkQGx/qaIiz7skaNXMEipLzBmDd3tuh+zhrvHpum1RK+ZCVoe74CLRWECIYV+DTQNNOluEuXJX+WRasEhQ=="
+		},
+		"immutable": {
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+			"integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -8415,7 +8846,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -8425,7 +8855,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.1.0"
 					}
@@ -8435,8 +8864,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"in-publish": {
 			"version": "2.0.0",
@@ -8466,7 +8894,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -8475,8 +8902,7 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -8498,6 +8924,15 @@
 				"semver": "2.x || 3.x || 4 || 5",
 				"validate-npm-package-license": "^3.0.1",
 				"validate-npm-package-name": "^3.0.0"
+			}
+		},
+		"inline-style-prefixer": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+			"integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+			"requires": {
+				"bowser": "^1.7.3",
+				"css-in-js-utils": "^2.0.0"
 			}
 		},
 		"inquirer": {
@@ -8575,7 +9010,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -8583,8 +9017,7 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -8620,7 +9053,6 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -8629,7 +9061,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8639,8 +9070,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -8654,14 +9084,12 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "^1.0.0"
 			}
@@ -8669,8 +9097,7 @@
 		"is-callable": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-			"dev": true
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -8685,7 +9112,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -8694,7 +9120,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8704,14 +9129,12 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-			"dev": true
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -8721,8 +9144,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -8741,14 +9163,12 @@
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
 			}
@@ -8756,8 +9176,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -8769,7 +9188,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -8778,10 +9196,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
+		},
+		"is-generator-fn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
 		},
 		"is-glob": {
 			"version": "4.0.0",
@@ -8802,7 +9224,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -8811,7 +9232,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8864,7 +9284,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -8872,14 +9291,12 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-promise": {
 			"version": "2.1.0",
@@ -8891,7 +9308,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.1"
 			}
@@ -8905,14 +9321,12 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-			"dev": true
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
 		},
 		"is-svg": {
 			"version": "2.1.0",
@@ -8927,7 +9341,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
 			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.0"
 			}
@@ -8944,20 +9357,17 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
@@ -8968,8 +9378,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isbuffer": {
 			"version": "0.0.0",
@@ -8980,32 +9389,73 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				}
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul-api": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
+			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
+			"requires": {
+				"async": "^2.1.4",
+				"fileset": "^2.0.2",
+				"istanbul-lib-coverage": "^1.2.1",
+				"istanbul-lib-hook": "^1.2.2",
+				"istanbul-lib-instrument": "^1.10.2",
+				"istanbul-lib-report": "^1.1.5",
+				"istanbul-lib-source-maps": "^1.2.6",
+				"istanbul-reports": "^1.5.1",
+				"js-yaml": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"once": "^1.4.0"
+			}
 		},
 		"istanbul-lib-coverage": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-			"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
-			"dev": true
+			"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ=="
+		},
+		"istanbul-lib-hook": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
+			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
+			"requires": {
+				"append-transform": "^0.4.0"
+			}
 		},
 		"istanbul-lib-instrument": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
 			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
-			"dev": true,
 			"requires": {
 				"babel-generator": "^6.18.0",
 				"babel-template": "^6.16.0",
@@ -9014,6 +9464,1269 @@
 				"babylon": "^6.18.0",
 				"istanbul-lib-coverage": "^1.2.1",
 				"semver": "^5.3.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
+			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+			"requires": {
+				"istanbul-lib-coverage": "^1.2.1",
+				"mkdirp": "^0.5.1",
+				"path-parse": "^1.0.5",
+				"supports-color": "^3.1.2"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
+			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+			"requires": {
+				"debug": "^3.1.0",
+				"istanbul-lib-coverage": "^1.2.1",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.1",
+				"source-map": "^0.5.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
+			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+			"requires": {
+				"handlebars": "^4.0.3"
+			}
+		},
+		"jest": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
+			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
+			"requires": {
+				"import-local": "^1.0.0",
+				"jest-cli": "^23.6.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"ci-info": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"requires": {
+						"ci-info": "^1.5.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"jest-cli": {
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
+					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
+						"is-ci": "^1.0.10",
+						"istanbul-api": "^1.3.1",
+						"istanbul-lib-coverage": "^1.2.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"istanbul-lib-source-maps": "^1.2.4",
+						"jest-changed-files": "^23.4.2",
+						"jest-config": "^23.6.0",
+						"jest-environment-jsdom": "^23.4.0",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^23.6.0",
+						"jest-message-util": "^23.4.0",
+						"jest-regex-util": "^23.3.0",
+						"jest-resolve-dependencies": "^23.6.0",
+						"jest-runner": "^23.6.0",
+						"jest-runtime": "^23.6.0",
+						"jest-snapshot": "^23.6.0",
+						"jest-util": "^23.4.0",
+						"jest-validate": "^23.6.0",
+						"jest-watcher": "^23.4.0",
+						"jest-worker": "^23.2.0",
+						"micromatch": "^2.3.11",
+						"node-notifier": "^5.2.1",
+						"prompts": "^0.1.9",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
+						"slash": "^1.0.0",
+						"string-length": "^2.0.0",
+						"strip-ansi": "^4.0.0",
+						"which": "^1.2.12",
+						"yargs": "^11.0.0"
+					}
+				},
+				"jest-worker": {
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+					"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+					"requires": {
+						"merge-stream": "^1.0.1"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"mem": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
+			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
+			"requires": {
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-config": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
+			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
+			"requires": {
+				"babel-core": "^6.0.0",
+				"babel-jest": "^23.6.0",
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^23.4.0",
+				"jest-environment-node": "^23.4.0",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-regex-util": "^23.3.0",
+				"jest-resolve": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-validate": "^23.6.0",
+				"micromatch": "^2.3.11",
+				"pretty-format": "^23.6.0"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"json5": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				}
+			}
+		},
+		"jest-diff": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
+			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
+			"requires": {
+				"chalk": "^2.0.1",
+				"diff": "^3.2.0",
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
+			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+			"requires": {
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
+			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
+			"requires": {
+				"chalk": "^2.0.1",
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
+			"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+			"requires": {
+				"jest-mock": "^23.2.0",
+				"jest-util": "^23.4.0",
+				"jsdom": "^11.5.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+				},
+				"jsdom": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+					"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+					"requires": {
+						"abab": "^2.0.0",
+						"acorn": "^5.5.3",
+						"acorn-globals": "^4.1.0",
+						"array-equal": "^1.0.0",
+						"cssom": ">= 0.3.2 < 0.4.0",
+						"cssstyle": "^1.0.0",
+						"data-urls": "^1.0.0",
+						"domexception": "^1.0.1",
+						"escodegen": "^1.9.1",
+						"html-encoding-sniffer": "^1.0.2",
+						"left-pad": "^1.3.0",
+						"nwsapi": "^2.0.7",
+						"parse5": "4.0.0",
+						"pn": "^1.1.0",
+						"request": "^2.87.0",
+						"request-promise-native": "^1.0.5",
+						"sax": "^1.2.4",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.3.4",
+						"w3c-hr-time": "^1.0.1",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.3",
+						"whatwg-mimetype": "^2.1.0",
+						"whatwg-url": "^6.4.1",
+						"ws": "^5.2.0",
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+				},
+				"whatwg-url": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"ws": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+					"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
+		},
+		"jest-environment-node": {
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
+			"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
+			"requires": {
+				"jest-mock": "^23.2.0",
+				"jest-util": "^23.4.0"
+			}
+		},
+		"jest-get-type": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+		},
+		"jest-haste-map": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
+			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
+			"requires": {
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"invariant": "^2.2.4",
+				"jest-docblock": "^23.2.0",
+				"jest-serializer": "^23.0.1",
+				"jest-worker": "^23.2.0",
+				"micromatch": "^2.3.11",
+				"sane": "^2.0.0"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"jest-worker": {
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+					"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+					"requires": {
+						"merge-stream": "^1.0.1"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				}
+			}
+		},
+		"jest-jasmine2": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
+			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
+			"requires": {
+				"babel-traverse": "^6.0.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^23.6.0",
+				"is-generator-fn": "^1.0.0",
+				"jest-diff": "^23.6.0",
+				"jest-each": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-snapshot": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
+			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
+			"requires": {
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
+			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
+			"requires": {
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
+			"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
+			"requires": {
+				"@babel/code-frame": "^7.0.0-beta.35",
+				"chalk": "^2.0.1",
+				"micromatch": "^2.3.11",
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				}
+			}
+		},
+		"jest-mock": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
+			"integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ="
+		},
+		"jest-regex-util": {
+			"version": "23.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
+			"integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U="
+		},
+		"jest-resolve": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
+			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
+			"requires": {
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"realpath-native": "^1.0.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
+			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
+			"requires": {
+				"jest-regex-util": "^23.3.0",
+				"jest-snapshot": "^23.6.0"
+			}
+		},
+		"jest-runner": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
+			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
+			"requires": {
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.6.0",
+				"jest-docblock": "^23.2.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-leak-detector": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-runtime": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-worker": "^23.2.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
+			},
+			"dependencies": {
+				"jest-worker": {
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+					"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+					"requires": {
+						"merge-stream": "^1.0.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"source-map-support": {
+					"version": "0.5.10",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+					"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
+			}
+		},
+		"jest-runtime": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
+			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
+			"requires": {
+				"babel-core": "^6.0.0",
+				"babel-plugin-istanbul": "^4.1.6",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"exit": "^0.1.2",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.6.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-regex-util": "^23.3.0",
+				"jest-resolve": "^23.6.0",
+				"jest-snapshot": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-validate": "^23.6.0",
+				"micromatch": "^2.3.11",
+				"realpath-native": "^1.0.0",
+				"slash": "^1.0.0",
+				"strip-bom": "3.0.0",
+				"write-file-atomic": "^2.1.0",
+				"yargs": "^11.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"json5": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"mem": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"jest-serializer": {
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
+			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
+		},
+		"jest-snapshot": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
+			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
+			"requires": {
+				"babel-types": "^6.0.0",
+				"chalk": "^2.0.1",
+				"jest-diff": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-resolve": "^23.6.0",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^23.6.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"jest-util": {
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
+			"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
+			"requires": {
+				"callsites": "^2.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.11",
+				"is-ci": "^1.0.10",
+				"jest-message-util": "^23.4.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"requires": {
+						"ci-info": "^1.5.0"
+					}
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"jest-validate": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
+			"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+			"requires": {
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.1.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
+			"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"string-length": "^2.0.0"
 			}
 		},
 		"jest-worker": {
@@ -9041,14 +10754,12 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.12.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
 			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -9057,8 +10768,7 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jsdom": {
 			"version": "13.1.0",
@@ -9109,14 +10819,12 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -9127,8 +10835,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json3": {
 			"version": "3.3.2",
@@ -9168,11 +10875,15 @@
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
+		"jsonschema": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -9195,14 +10906,12 @@
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-			"dev": true
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 		},
 		"kleur": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-			"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
-			"dev": true
+			"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ=="
 		},
 		"last-call-webpack-plugin": {
 			"version": "3.0.0",
@@ -9230,10 +10939,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
+		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
 		},
 		"lerna": {
 			"version": "3.10.5",
@@ -9496,11 +11209,15 @@
 				}
 			}
 		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
@@ -9721,11 +11438,18 @@
 			"integrity": "sha512-J9tg5uraYoQKaWbmrzDDexbG6hHnMcWS1qLYgJSWE+mpA3U5OCSeMUhb+K55otgZJ34oFdR0ECvdIb3xuO5JOQ==",
 			"dev": true
 		},
+		"linkify-it": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
+			"integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+			"requires": {
+				"uc.micro": "^1.0.1"
+			}
+		},
 		"load-json-file": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
@@ -9738,12 +11462,16 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
 				}
 			}
+		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
 		},
 		"loader-runner": {
 			"version": "2.4.0",
@@ -9783,7 +11511,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
@@ -9802,8 +11529,7 @@
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-			"dev": true
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -9817,6 +11543,16 @@
 			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
 			"dev": true
 		},
+		"lodash.assignin": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+		},
+		"lodash.bind": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+			"integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -9829,11 +11565,41 @@
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
 		},
+		"lodash.cond": {
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
+		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
+		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+		},
+		"lodash.filter": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+			"integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+		},
+		"lodash.foreach": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
 		},
 		"lodash.get": {
 			"version": "4.4.2",
@@ -9847,11 +11613,25 @@
 			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
 			"dev": true
 		},
+		"lodash.keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
+		},
+		"lodash.map": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+			"integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+		},
+		"lodash.merge": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
 		},
 		"lodash.mergewith": {
 			"version": "4.6.1",
@@ -9859,11 +11639,30 @@
 			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
 			"dev": true
 		},
+		"lodash.pick": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+		},
+		"lodash.reduce": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+			"integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+		},
+		"lodash.reject": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+			"integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+		},
+		"lodash.some": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.tail": {
 			"version": "4.1.1",
@@ -9893,8 +11692,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-			"dev": true
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"lodash.zip": {
 			"version": "4.2.0",
@@ -9912,7 +11710,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -9937,7 +11734,6 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -10078,6 +11874,14 @@
 				}
 			}
 		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"requires": {
+				"tmpl": "1.0.x"
+			}
+		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -10090,8 +11894,7 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-obj": {
 			"version": "2.0.0",
@@ -10103,7 +11906,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -10117,8 +11919,7 @@
 		"math-random": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
-			"dev": true
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -10243,6 +12044,11 @@
 				}
 			}
 		},
+		"merge": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+		},
 		"merge-deep": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
@@ -10275,7 +12081,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
 			}
@@ -10296,7 +12101,6 @@
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -10332,14 +12136,12 @@
 		"mime-db": {
 			"version": "1.37.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-			"dev": true
+			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
 		},
 		"mime-types": {
 			"version": "2.1.21",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
 			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-			"dev": true,
 			"requires": {
 				"mime-db": "~1.37.0"
 			}
@@ -10347,8 +12149,7 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mini-css-extract-plugin": {
 			"version": "0.4.5",
@@ -10377,7 +12178,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -10385,8 +12185,7 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -10447,7 +12246,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -10457,7 +12255,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -10486,9 +12283,70 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+			"requires": {
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.5",
+				"he": "1.1.1",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"supports-color": "5.4.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"mocha-teamcity-reporter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/mocha-teamcity-reporter/-/mocha-teamcity-reporter-1.1.1.tgz",
+			"integrity": "sha1-aW5ns9PTv3Iiw2CPNSNTf4VBFDk=",
+			"requires": {
+				"mocha": ">=1.13.0"
 			}
 		},
 		"modify-values": {
@@ -10526,8 +12384,7 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -10566,14 +12423,12 @@
 		"nan": {
 			"version": "2.12.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-			"dev": true
+			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -10591,8 +12446,7 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-			"dev": true
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"ncp": {
 			"version": "0.4.2",
@@ -10684,6 +12538,11 @@
 				}
 			}
 		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+		},
 		"node-libs-browser": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
@@ -10721,6 +12580,17 @@
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
 				}
+			}
+		},
+		"node-notifier": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
+			"integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
+			"requires": {
+				"growly": "^1.3.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
 			}
 		},
 		"node-releases": {
@@ -10895,7 +12765,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"is-builtin-module": "^1.0.0",
@@ -10907,7 +12776,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
@@ -11028,7 +12896,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -11049,7 +12916,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
 			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
@@ -11063,32 +12929,27 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
 			"version": "2.0.9",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
-			"dev": true
+			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ=="
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -11099,7 +12960,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -11108,24 +12968,26 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
 				}
 			}
 		},
+		"object-is": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+		},
 		"object-keys": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-			"dev": true
+			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			}
@@ -11134,12 +12996,22 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
 				"has-symbols": "^1.0.0",
 				"object-keys": "^1.0.11"
+			}
+		},
+		"object.entries": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+			"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.12.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
 			}
 		},
 		"object.fromentries": {
@@ -11158,7 +13030,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
@@ -11168,7 +13039,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
@@ -11178,7 +13048,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -11187,7 +13056,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
 			"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.12.0",
@@ -11226,7 +13094,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -11259,7 +13126,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -11268,8 +13134,7 @@
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 				}
 			}
 		},
@@ -11287,7 +13152,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.4",
@@ -11315,8 +13179,7 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "1.4.0",
@@ -11340,8 +13203,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -11373,8 +13235,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
@@ -11386,7 +13247,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-			"dev": true,
 			"requires": {
 				"p-try": "^1.0.0"
 			}
@@ -11395,7 +13255,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "^1.1.0"
 			}
@@ -11436,8 +13295,7 @@
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"p-waterfall": {
 			"version": "1.0.0",
@@ -11614,7 +13472,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
 				"is-dotfile": "^1.0.0",
@@ -11625,14 +13482,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -11680,8 +13535,7 @@
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-browserify": {
 			"version": "0.0.0",
@@ -11698,14 +13552,12 @@
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -11716,14 +13568,12 @@
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -11735,7 +13585,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"pify": "^2.0.0",
@@ -11758,26 +13607,22 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -11860,8 +13705,7 @@
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
 		},
 		"portfinder": {
 			"version": "1.0.20",
@@ -11885,8 +13729,7 @@
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
 			"version": "5.2.18",
@@ -12607,11 +14450,15 @@
 				"uniqs": "^2.0.0"
 			}
 		},
+		"prefix-style": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/prefix-style/-/prefix-style-2.0.1.tgz",
+			"integrity": "sha1-ZrupqHDP2jCKXcIOhekSCTLJWgY="
+		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
 			"version": "1.0.4",
@@ -12622,8 +14469,7 @@
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"prettier": {
 			"version": "1.15.3",
@@ -12631,11 +14477,43 @@
 			"integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
 			"dev": true
 		},
+		"prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"dev": true,
+			"requires": {
+				"fast-diff": "^1.1.2"
+			}
+		},
+		"pretty-format": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+			"requires": {
+				"ansi-regex": "^3.0.0",
+				"ansi-styles": "^3.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				}
+			}
+		},
+		"prismjs": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
+			"integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
+			"requires": {
+				"clipboard": "^2.0.0"
+			}
+		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
 			"version": "0.11.10",
@@ -12652,14 +14530,21 @@
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "~2.0.3"
+			}
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -12700,7 +14585,6 @@
 			"version": "0.1.14",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
 			"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
-			"dev": true,
 			"requires": {
 				"kleur": "^2.0.1",
 				"sisteransi": "^0.1.1"
@@ -12719,7 +14603,6 @@
 			"version": "15.6.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
 			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.3.1",
 				"object-assign": "^4.1.1"
@@ -12759,14 +14642,12 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
 			"version": "1.1.31",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-			"dev": true
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -12806,8 +14687,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"q": {
 			"version": "1.5.1",
@@ -12818,8 +14698,7 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"query-string": {
 			"version": "4.3.4",
@@ -12855,6 +14734,14 @@
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
 			"dev": true
 		},
+		"raf": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+			"requires": {
+				"performance-now": "^2.1.0"
+			}
+		},
 		"ramda": {
 			"version": "0.25.0",
 			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
@@ -12865,7 +14752,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
 			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0",
 				"kind-of": "^6.0.0",
@@ -12875,8 +14761,7 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				}
 			}
 		},
@@ -12926,6 +14811,117 @@
 						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				}
+			}
+		},
+		"react": {
+			"version": "15.5.4",
+			"resolved": "https://registry.npmjs.org/react/-/react-15.5.4.tgz",
+			"integrity": "sha1-+oPrAVBqsjfNwcjDsc6o3gEr8Ec=",
+			"requires": {
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.0",
+				"prop-types": "^15.5.7"
+			}
+		},
+		"react-click-outside": {
+			"version": "github:tj/react-click-outside#a833ddc5be47490307f9fcc6ed09d8c353108510",
+			"from": "github:tj/react-click-outside"
+		},
+		"react-custom-scrollbars": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz",
+			"integrity": "sha1-gw/ZUCkn6X6KeMIIaBOJmyqLZts=",
+			"requires": {
+				"dom-css": "^2.0.0",
+				"prop-types": "^15.5.10",
+				"raf": "^3.1.0"
+			}
+		},
+		"react-dom": {
+			"version": "15.5.4",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz",
+			"integrity": "sha1-ugwoeG/VLtfk8hNf4CiNRirvk9o=",
+			"requires": {
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.0",
+				"prop-types": "~15.5.7"
+			},
+			"dependencies": {
+				"prop-types": {
+					"version": "15.5.10",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+					"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+					"requires": {
+						"fbjs": "^0.8.9",
+						"loose-envify": "^1.3.1"
+					}
+				}
+			}
+		},
+		"react-i18next": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-7.13.0.tgz",
+			"integrity": "sha512-35M+MZFPqHwVIas7tXWQKFrf+ozCJukNplUTiGqL8mczSk+VRBsHxxXuuQKRkz/4CcWkONGWbp/AzxfM6wZncg==",
+			"requires": {
+				"hoist-non-react-statics": "^2.3.1",
+				"html-parse-stringify2": "2.0.1",
+				"prop-types": "^15.6.0"
+			}
+		},
+		"react-icon-base": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
+			"integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50="
+		},
+		"react-icons": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.7.tgz",
+			"integrity": "sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==",
+			"requires": {
+				"react-icon-base": "2.1.0"
+			}
+		},
+		"react-infinite-scroller": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.4.tgz",
+			"integrity": "sha512-/oOa0QhZjXPqaD6sictN2edFMsd3kkMiE19Vcz5JDgHpzEJVqYcmq+V3mkwO88087kvKGe1URNksHEOt839Ubw==",
+			"requires": {
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-md-spinner": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/react-md-spinner/-/react-md-spinner-0.3.0.tgz",
+			"integrity": "sha512-7MZx3eSCjUNocTQuYFzt2BF3J69s9UNSnOG2I6R+Yg2okbi3VzRVY0Ers7C7dTXHhpNMYeQoaI1juIz72r3bng==",
+			"requires": {
+				"caniuse-api": "^1.6.1",
+				"css-keyframer": "1.0.1",
+				"exenv": "^1.2.1",
+				"inline-style-prefixer": "^3.0.3",
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-measure": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.2.2.tgz",
+			"integrity": "sha512-7cnTiqUfS08o2VQ+tZ614/MSpzgr5NiSWF3mmWM2MbvL1r8V20LXJZ1Mpyi0Nfwf7G1bP692eGCmgOc0fsWvFg==",
+			"requires": {
+				"@babel/runtime": "^7.2.0",
+				"get-node-dimensions": "^1.2.1",
+				"prop-types": "^15.6.2",
+				"resize-observer-polyfill": "^1.5.0"
+			}
+		},
+		"react-player": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/react-player/-/react-player-1.8.0.tgz",
+			"integrity": "sha512-DqIJvkL7itGLgs/8u+sgeD3DXq5kc/O6FsB6J9KEuoaiYiSKhluBRymZWIwfCuPNTdpPsA2roZ+NSCyLrHAA9g==",
+			"requires": {
+				"deepmerge": "^2.0.1",
+				"load-script": "^1.0.0",
+				"prop-types": "^15.5.6"
 			}
 		},
 		"react-svg-core": {
@@ -13044,6 +15040,24 @@
 				"react-svg-core": "^2.1.0"
 			}
 		},
+		"react-test-renderer": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.2.tgz",
+			"integrity": "sha1-0DM0NPwsQ4CSaWyncNpe1IA376g=",
+			"requires": {
+				"fbjs": "^0.8.9",
+				"object-assign": "^4.1.0"
+			}
+		},
+		"react-tooltip": {
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.9.2.tgz",
+			"integrity": "sha512-uoOXt/LVX9JhSYjAa3F2qSJuaTwod1fW2PWJGWGZ7Sfm6M8/JGWvGY1LsR51g8LYteVcSbDFuHfuB3rmNFACRw==",
+			"requires": {
+				"classnames": "^2.2.5",
+				"prop-types": "^15.6.0"
+			}
+		},
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -13100,7 +15114,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-			"dev": true,
 			"requires": {
 				"load-json-file": "^1.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -13111,7 +15124,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"dev": true,
 			"requires": {
 				"find-up": "^1.0.0",
 				"read-pkg": "^1.0.0"
@@ -13121,7 +15133,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -13131,7 +15142,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -13142,7 +15152,6 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -13176,6 +15185,14 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
+		"realpath-native": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
+			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+			"requires": {
+				"util.promisify": "^1.0.0"
+			}
+		},
 		"recursive-readdir": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -13193,6 +15210,14 @@
 			"requires": {
 				"indent-string": "^3.0.0",
 				"strip-indent": "^2.0.0"
+			}
+		},
+		"redraft": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/redraft/-/redraft-0.9.1.tgz",
+			"integrity": "sha512-L3SZVuqASQ/2pHCEKlzLCZ4s6gT9mr01evIoHKbfa4vB7x4FpLoF2sbBTkwM2lYMaLqpXWx4y9owfC4Ad8jvVA==",
+			"requires": {
+				"punycode": "^2.1.0"
 			}
 		},
 		"reduce-css-calc": {
@@ -13249,8 +15274,7 @@
 		"regenerator-runtime": {
 			"version": "0.12.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-			"dev": true
+			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"regenerator-transform": {
 			"version": "0.13.3",
@@ -13265,7 +15289,6 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
 			}
@@ -13274,7 +15297,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -13326,26 +15348,22 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-			"dev": true
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -13360,7 +15378,6 @@
 			"version": "2.88.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -13387,14 +15404,12 @@
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				},
 				"tough-cookie": {
 					"version": "2.4.3",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-					"dev": true,
 					"requires": {
 						"psl": "^1.1.24",
 						"punycode": "^1.4.1"
@@ -13406,7 +15421,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.13.1"
 			}
@@ -13415,7 +15429,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "^1.1.0",
@@ -13425,8 +15438,7 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-from-string": {
 			"version": "1.2.1",
@@ -13437,8 +15449,7 @@
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"require-uncached": {
 			"version": "1.0.3",
@@ -13491,11 +15502,15 @@
 			"integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
 			"dev": true
 		},
+		"resize-observer-polyfill": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+		},
 		"resolve": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
 			"integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -13504,7 +15519,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
 			}
@@ -13522,14 +15536,12 @@
 		"resolve-from": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-			"dev": true
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
@@ -13544,8 +15556,7 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"retry": {
 			"version": "0.10.1",
@@ -13563,7 +15574,6 @@
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -13861,6 +15871,11 @@
 				}
 			}
 		},
+		"rsvp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -13912,14 +15927,12 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -13927,8 +15940,30 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"sane": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+			"requires": {
+				"anymatch": "^2.0.0",
+				"capture-exit": "^1.2.0",
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.2.3",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.18.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
 		},
 		"sass-graph": {
 			"version": "2.2.4",
@@ -14051,8 +16086,7 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"saxes": {
 			"version": "3.1.5",
@@ -14103,6 +16137,12 @@
 				}
 			}
 		},
+		"select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+			"optional": true
+		},
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -14121,8 +16161,7 @@
 		"semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-			"dev": true
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
 		},
 		"semver-compare": {
 			"version": "1.0.0",
@@ -14195,14 +16234,12 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -14214,7 +16251,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -14224,8 +16260,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
 			"version": "1.1.0",
@@ -14276,7 +16311,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -14284,20 +16318,22 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sisteransi": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
-			"integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==",
-			"dev": true
+			"integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g=="
 		},
 		"slash": {
 			"version": "2.0.0",
@@ -14338,7 +16374,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -14354,7 +16389,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -14363,7 +16397,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -14374,7 +16407,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -14385,7 +16417,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -14394,7 +16425,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -14403,7 +16433,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -14412,7 +16441,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -14425,7 +16453,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			},
@@ -14434,7 +16461,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -14538,8 +16564,7 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-loader": {
 			"version": "0.2.4",
@@ -14555,7 +16580,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -14568,7 +16592,6 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6"
 			}
@@ -14576,8 +16599,7 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"sourcemap-codec": {
 			"version": "1.4.4",
@@ -14589,7 +16611,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
 			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -14598,14 +16619,12 @@
 		"spdx-exceptions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-			"dev": true
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -14614,8 +16633,7 @@
 		"spdx-license-ids": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
-			"dev": true
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
 		},
 		"spdy": {
 			"version": "4.0.0",
@@ -14702,7 +16720,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -14719,14 +16736,12 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
 			"integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
-			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -14760,11 +16775,15 @@
 			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
 			"dev": true
 		},
+		"stack-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -14774,7 +16793,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -14799,8 +16817,7 @@
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-			"dev": true
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"stream-browserify": {
 			"version": "2.0.1",
@@ -14853,6 +16870,30 @@
 			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
 			"dev": true
 		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"requires": {
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
 		"string-range": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz",
@@ -14863,7 +16904,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"dev": true,
 			"requires": {
 				"code-point-at": "^1.0.0",
 				"is-fullwidth-code-point": "^1.0.0",
@@ -14874,7 +16914,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -14895,7 +16934,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -14904,7 +16942,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true,
 			"requires": {
 				"is-utf8": "^0.2.0"
 			}
@@ -14912,8 +16949,7 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
 			"version": "2.0.0",
@@ -14984,7 +17020,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -15260,8 +17295,12 @@
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-			"dev": true
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+		},
+		"tabbable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.3.tgz",
+			"integrity": "sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg=="
 		},
 		"table": {
 			"version": "4.0.2",
@@ -15527,7 +17566,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
 			"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"micromatch": "^2.3.11",
@@ -15540,7 +17578,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
 					}
@@ -15548,14 +17585,12 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "^1.8.1",
 						"preserve": "^0.2.0",
@@ -15566,7 +17601,6 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
 					}
@@ -15575,7 +17609,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -15583,14 +17616,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -15599,7 +17630,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -15608,7 +17638,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^2.0.0",
 						"array-unique": "^0.2.1",
@@ -15638,6 +17667,11 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
 		},
 		"through": {
 			"version": "2.3.8",
@@ -15670,14 +17704,29 @@
 				"setimmediate": "^1.0.4"
 			}
 		},
+		"tiny-emitter": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+			"integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
+			"optional": true
+		},
+		"tlds": {
+			"version": "1.203.1",
+			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
+			"integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw=="
+		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
 		},
 		"to-arraybuffer": {
 			"version": "1.0.1",
@@ -15685,17 +17734,29 @@
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
 			"dev": true
 		},
+		"to-camel-case": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
+			"integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
+			"requires": {
+				"to-space-case": "^1.0.0"
+			}
+		},
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
+		"to-no-case": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+			"integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
+		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -15704,7 +17765,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -15715,7 +17775,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -15727,17 +17786,28 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
 			}
 		},
+		"to-space-case": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+			"integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+			"requires": {
+				"to-no-case": "^1.0.0"
+			}
+		},
+		"to-style": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/to-style/-/to-style-1.3.3.tgz",
+			"integrity": "sha1-Y6K3Cm9KfU/cLtV6C+TnI1y2aZw="
+		},
 		"tough-cookie": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"dev": true,
 			"requires": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -15747,7 +17817,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -15767,8 +17836,7 @@
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"true-case-path": {
 			"version": "1.0.3",
@@ -15801,7 +17869,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -15809,14 +17876,12 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -15849,11 +17914,20 @@
 			"integrity": "sha512-U1WMNp4qfy4/3khIfHMVAIKnNu941MXUfs3+H9R8PFgnoz42Hh9pboSFztWr86zut0eXC8byalmVhfkiKON/8Q==",
 			"dev": true
 		},
+		"ua-parser-js": {
+			"version": "0.7.19",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+		},
+		"uc.micro": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+			"integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
+		},
 		"uglify-js": {
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
@@ -15864,14 +17938,12 @@
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-					"dev": true,
 					"optional": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -15992,11 +18064,15 @@
 			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
 			"dev": true
 		},
+		"union-class-names": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-class-names/-/union-class-names-1.0.0.tgz",
+			"integrity": "sha1-kllgitrMOQlKKwz+FseOYgBheEc="
+		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -16008,7 +18084,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -16017,7 +18092,6 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -16088,7 +18162,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -16098,7 +18171,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -16109,7 +18181,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -16119,8 +18190,7 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				}
 			}
 		},
@@ -16149,7 +18219,6 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -16157,8 +18226,7 @@
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
@@ -16222,8 +18290,7 @@
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"dev": true
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"util": {
 			"version": "0.10.4",
@@ -16237,14 +18304,12 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"object.getownpropertydescriptors": "^2.0.3"
@@ -16281,8 +18346,7 @@
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.2",
@@ -16294,7 +18358,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -16325,7 +18388,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -16341,11 +18403,15 @@
 				"indexof": "0.0.1"
 			}
 		},
+		"void-elements": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+			"integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+		},
 		"w3c-hr-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
 			}
@@ -16359,6 +18425,30 @@
 				"domexception": "^1.0.1",
 				"webidl-conversions": "^4.0.2",
 				"xml-name-validator": "^3.0.0"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"requires": {
+				"makeerror": "1.0.x"
+			}
+		},
+		"watch": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+			"requires": {
+				"exec-sh": "^0.2.0",
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"watchpack": {
@@ -16393,8 +18483,7 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-			"dev": true
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
 			"version": "4.28.4",
@@ -16999,22 +19088,24 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
 			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
 		},
+		"whatwg-fetch": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
-			"dev": true
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
 		},
 		"whatwg-url": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
 			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
-			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
@@ -17031,7 +19122,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -17131,11 +19221,20 @@
 				}
 			}
 		},
+		"wnpm-ci": {
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/wnpm-ci/-/wnpm-ci-7.0.8.tgz",
+			"integrity": "sha512-jYdIk5K+BP9bExBWCglT2NAJxvY3UjVkA8WJwQJ3rS8Loo9r8wm/Iw23KZUBxCjIA+/ZTb2Q/6ZNJhTWD09syQ==",
+			"requires": {
+				"mocha-teamcity-reporter": "^1.1.1",
+				"semver": "^5.2.0",
+				"tmp": "0.0.33"
+			}
+		},
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"dev": true
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"worker-farm": {
 			"version": "1.6.0",
@@ -17150,7 +19249,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -17159,8 +19257,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",
@@ -17175,7 +19272,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -17252,8 +19348,7 @@
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-			"dev": true
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 		},
 		"xmlchars": {
 			"version": "1.3.1",
@@ -17291,8 +19386,7 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "6.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13716,6 +13716,17 @@
 				}
 			}
 		},
+		"rollup-plugin-replace": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.1.0.tgz",
+			"integrity": "sha512-SxrAIgpH/B5/W4SeULgreOemxcpEgKs2gcD42zXw50bhqGWmcnlXneVInQpAqzA/cIly4bJrOpeelmB9p4YXSQ==",
+			"dev": true,
+			"requires": {
+				"magic-string": "^0.25.1",
+				"minimatch": "^3.0.2",
+				"rollup-pluginutils": "^2.0.1"
+			}
+		},
 		"rollup-plugin-terser": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-lodash": "^2.7.0",
+    "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.7.0",
     "husky": "^1.0.0-rc.6",
     "lerna": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-postcss": "^1.6.3",
+    "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.2",
     "rollup-plugin-visualizer": "^0.9.2",
     "sass-loader": "^7.0.1",
@@ -79,8 +80,8 @@
     "webpack": "^4.12.0",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.0.4",
-    "webpack-merge": "^4.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.1.14",
+    "webpack-merge": "^4.1.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:common -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "lint": "eslint 'src/**/*.{js,jsx}'",
     "pretest": "npm run lint",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:common -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "lint": "eslint 'src/**/*.{js,jsx}'",
     "pretest": "npm run lint",

--- a/packages/common/src/Utils/component-data-validator.js
+++ b/packages/common/src/Utils/component-data-validator.js
@@ -1,10 +1,10 @@
-import { Validator } from 'jsonschema';
-
-const validator = new Validator();
-
 export const validate = (componentData, schema) => {
-  const result = validator.validate(componentData, schema);
-  if (!result.valid && result.errors) {
-    result.errors.forEach(error => console.warn('Plugin schema validation error:', error)); // eslint-disable-line no-console
+  const Validator = require('jsonschema').Validator;
+  if (process.env.NODE_ENV !== 'production') {
+    const validator = new Validator();
+    const result = validator.validate(componentData, schema);
+    if (!result.valid && result.errors) {
+      result.errors.forEach(error => console.warn('Plugin schema validation error:', error)); // eslint-disable-line no-console
+    }
   }
 };

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -19,7 +19,7 @@
     "build": "rollup --environment MODULE_NAME:editor -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "lint": "eslint 'src/**/*.{js,jsx}'",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -19,7 +19,7 @@
     "build": "rollup --environment MODULE_NAME:editor -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "lint": "eslint 'src/**/*.{js,jsx}'",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/plugin-code-block/package.json
+++ b/packages/plugin-code-block/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-code-block -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-code-block/package.json
+++ b/packages/plugin-code-block/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-code-block -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-divider/package.json
+++ b/packages/plugin-divider/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-divider -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-divider/package.json
+++ b/packages/plugin-divider/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-divider -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-emoji/package.json
+++ b/packages/plugin-emoji/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-emoji -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-emoji/package.json
+++ b/packages/plugin-emoji/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-emoji -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-giphy/package.json
+++ b/packages/plugin-giphy/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-giphy -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-giphy/package.json
+++ b/packages/plugin-giphy/package.json
@@ -26,7 +26,7 @@
     "prebuild": "npm run statics",
     "build": "rollup --environment MODULE_NAME:plugin-giphy -c ../../rollup.config.js",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-giphy/package.json
+++ b/packages/plugin-giphy/package.json
@@ -25,6 +25,7 @@
     "statics": "mkdir -p dist && cp -R statics dist/statics",
     "prebuild": "npm run statics",
     "build": "rollup --environment MODULE_NAME:plugin-giphy -c ../../rollup.config.js",
+    "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
     "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",

--- a/packages/plugin-hashtag/package.json
+++ b/packages/plugin-hashtag/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-hashtag -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-hashtag/package.json
+++ b/packages/plugin-hashtag/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-hashtag -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-html/package.json
+++ b/packages/plugin-html/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-html -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-html/package.json
+++ b/packages/plugin-html/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-html -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-image/package.json
+++ b/packages/plugin-image/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-image -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-image/package.json
+++ b/packages/plugin-image/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-image -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-image/src/image-viewer.jsx
+++ b/packages/plugin-image/src/image-viewer.jsx
@@ -20,12 +20,18 @@ const getDefault = () => ({
 });
 
 class ImageViewer extends React.Component {
-
   constructor(props) {
     super(props);
     validate(props.componentData, schema);
     this.styles = mergeStyles({ styles, theme: props.theme });
-    this.state = {};
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  componentDidCatch(error) {
+    console.error(error); //eslint-disable-line
+    this.setState({ hasError: true });
   }
 
   componentDidMount() {
@@ -46,7 +52,7 @@ class ImageViewer extends React.Component {
 
     const imageUrl = {
       preload: '',
-      highres: ''
+      highres: '',
     };
 
     if (this.props.dataUrl) {
@@ -59,14 +65,19 @@ class ImageViewer extends React.Component {
         if (this.props.isMobile) {
           //adjust the image width to viewport scaling and device pixel ratio
           requiredWidth *= (window && window.devicePixelRatio) || 1;
-          requiredWidth *= (window && (window.screen.width / document.body.clientWidth)) || 1;
+          requiredWidth *= (window && window.screen.width / document.body.clientWidth) || 1;
         }
         //keep the image's original ratio
-        let requiredHeight = (src.height && src.width) ? Math.ceil((src.height / src.width) * requiredWidth) : 2048;
+        let requiredHeight = src.height && src.width ? Math.ceil((src.height / src.width) * requiredWidth) : 2048;
         requiredWidth = Math.ceil(requiredWidth);
         requiredHeight = Math.ceil(requiredHeight);
 
-        imageUrl.highres = getImageSrc(src, helpers, { requiredWidth, requiredHeight, requiredQuality: 90, imageType: 'highRes' });
+        imageUrl.highres = getImageSrc(src, helpers, {
+          requiredWidth,
+          requiredHeight,
+          requiredQuality: 90,
+          imageType: 'highRes',
+        });
       }
     }
 
@@ -85,13 +96,20 @@ class ImageViewer extends React.Component {
   renderImage(imageClassName, imageSrc, alt, props) {
     return [
       <img
-        key="preload" ref={ref => this.preloadImage = ref}
-        className={classNames(imageClassName, this.styles.imagePreload)} src={imageSrc.preload} alt={alt}
+        key='preload'
+        ref={ref => (this.preloadImage = ref)}
+        className={classNames(imageClassName, this.styles.imagePreload)}
+        src={imageSrc.preload}
+        alt={alt}
       />,
       <img
-        {...props} key="highres" className={classNames(imageClassName, this.styles.imageHighres)} src={imageSrc.highres} alt={alt}
+        {...props}
+        key='highres'
+        className={classNames(imageClassName, this.styles.imageHighres)}
+        src={imageSrc.highres}
+        alt={alt}
         onLoad={e => this.onHighResLoad(e)}
-      />
+      />,
     ];
   }
 
@@ -99,7 +117,11 @@ class ImageViewer extends React.Component {
     if (!this.props.isLoading) {
       return null;
     }
-    return <div className={this.styles.imageOverlay}><ImageLoader type={'medium'} theme={this.props.theme} /></div>;
+    return (
+      <div className={this.styles.imageOverlay}>
+        <ImageLoader type={'medium'} theme={this.props.theme} />
+      </div>
+    );
   }
 
   renderTitle(data, styles) {
@@ -109,16 +131,16 @@ class ImageViewer extends React.Component {
 
   renderDescription(data, styles) {
     const config = data.config || {};
-    return !!config.showDescription &&
-      <div className={classNames(styles.imageDescription)}>{(data && data.description) || ''}</div>;
+    return !!config.showDescription && <div className={classNames(styles.imageDescription)}>{(data && data.description) || ''}</div>;
   }
 
   renderCaption(caption, isFocused, readOnly, styles, defaultCaption) {
-
-    return (
-      caption ?
-        <div className={styles.imageCaption} data-hook="imageViewerCaption">{caption}</div> :
-        (!readOnly && isFocused && defaultCaption) && <div className={styles.imageCaption}>{defaultCaption}</div>
+    return caption ? (
+      <div className={styles.imageCaption} data-hook='imageViewerCaption'>
+        {caption}
+      </div>
+    ) : (
+      !readOnly && isFocused && defaultCaption && <div className={styles.imageCaption}>{defaultCaption}</div>
     );
   }
 
@@ -147,6 +169,10 @@ class ImageViewer extends React.Component {
   }
 
   render() {
+    if (this.state.hasError) {
+      return null;
+    }
+
     const { styles } = this;
     const { componentData, className, onClick, isFocused, readOnly, settings, defaultCaption } = this.props;
     const data = componentData || getDefault();
@@ -166,7 +192,10 @@ class ImageViewer extends React.Component {
     /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
       <div
-        data-hook="imageViewer" onClick={onClick} className={itemClassName} onKeyDown={e => this.onKeyDown(e, onClick)}
+        data-hook='imageViewer'
+        onClick={onClick}
+        className={itemClassName}
+        onKeyDown={e => this.onKeyDown(e, onClick)}
         ref={e => this.handleRef(e)}
       >
         <div className={styles.imageWrapper}>
@@ -179,7 +208,6 @@ class ImageViewer extends React.Component {
       </div>
     );
     /* eslint-enable jsx-a11y/no-static-element-interactions */
-
   }
 }
 

--- a/packages/plugin-link/package.json
+++ b/packages/plugin-link/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-link -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-link/package.json
+++ b/packages/plugin-link/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-link -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-mentions/package.json
+++ b/packages/plugin-mentions/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-mentions -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-mentions/package.json
+++ b/packages/plugin-mentions/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-mentions -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-sound-cloud/package.json
+++ b/packages/plugin-sound-cloud/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-sound-cloud -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-sound-cloud/package.json
+++ b/packages/plugin-sound-cloud/package.json
@@ -26,7 +26,7 @@
     "prebuild": "npm run statics",
     "build": "rollup --environment MODULE_NAME:plugin-sound-cloud -c ../../rollup.config.js",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-sound-cloud/package.json
+++ b/packages/plugin-sound-cloud/package.json
@@ -25,6 +25,7 @@
     "statics": "mkdir -p dist && cp -R statics dist/statics",
     "prebuild": "npm run statics",
     "build": "rollup --environment MODULE_NAME:plugin-sound-cloud -c ../../rollup.config.js",
+    "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
     "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",

--- a/packages/plugin-video/package.json
+++ b/packages/plugin-video/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-video -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-video/package.json
+++ b/packages/plugin-video/package.json
@@ -27,7 +27,7 @@
     "build": "rollup --environment MODULE_NAME:plugin-video -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/plugin-video/src/video-viewer.jsx
+++ b/packages/plugin-video/src/video-viewer.jsx
@@ -13,6 +13,14 @@ class VideoViewer extends Component {
     super(props);
     validate(props.componentData, schema);
     this.styles = mergeStyles({ styles, theme: props.theme });
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  componentDidCatch(error) {
+    console.error(error); // eslint-disable-line
+    this.setState({ hasError: true });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -22,14 +30,11 @@ class VideoViewer extends Component {
   }
 
   render() {
+    if (this.state.hasError) {
+      return null;
+    }
     const { componentData, theme, settings, isMobile, ...rest } = this.props; // eslint-disable-line no-unused-vars
-    return (
-      <ReactPlayer
-        className={classNames(this.styles.video_player)}
-        url={getVideoSrc(componentData.src, settings)}
-        {...rest}
-      />
-    );
+    return <ReactPlayer className={classNames(this.styles.video_player)} url={getVideoSrc(componentData.src, settings)} {...rest} />;
   }
 }
 

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -18,7 +18,7 @@
     "build": "rollup --environment MODULE_NAME:viewer -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
+    "watch": "NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -18,7 +18,7 @@
     "build": "rollup --environment MODULE_NAME:viewer -c ../../rollup.config.js",
     "build:dev": "NODE_ENV=development npm run build",
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
-    "watch": "MODULE_WATCH=1 npm run build -- --watch",
+    "watch": "MODULE_WATCH=1 npm run build:dev -- --watch",
     "release": "wnpm-release --no-shrinkwrap",
     "test": "eslint 'src/**/*.{js,jsx}'"
   },

--- a/packages/viewer/src/Preview.jsx
+++ b/packages/viewer/src/Preview.jsx
@@ -20,9 +20,10 @@ const withTextAlignment = (element, data, mergedStyles, textDirection) => {
     className: classNames(
       {
         [element.props.className]: !!element.props.className,
-        [mergedStyles.rtl]: appliedTextDirection === 'rtl'
+        [mergedStyles.rtl]: appliedTextDirection === 'rtl',
       },
-      mergedStyles[alignmentClass])
+      mergedStyles[alignmentClass]
+    ),
   };
   return React.cloneElement(element, elementProps, element.props.children);
 };
@@ -32,72 +33,117 @@ const getInline = mergedStyles => {
     BOLD: (children, { key }) => <strong key={key}>{children}</strong>,
     ITALIC: (children, { key }) => <em key={key}>{children}</em>,
     UNDERLINE: (children, { key }) => <u key={key}>{children}</u>,
-    CODE: (children, { key }) => <span key={key} className={mergedStyles.code}>{children}</span>
+    CODE: (children, { key }) => (
+      <span key={key} className={mergedStyles.code}>
+        {children}
+      </span>
+    ),
   };
 };
 
-const getList = (ordered, mergedStyles, textDirection) =>
-  (children, blockProps) => {
-    const fixedChildren = children.map(child => child.length ? child : [' ']);
-    const className = ordered ? 'ordered' : 'unordered';
-    const containerClassName = mergedStyles[`${className}ListContainer`];
-    return (
-      <List key={blockProps.keys[0]} keys={blockProps.keys} depth={blockProps.depth} ordered={ordered} className={containerClassName}>
-        {fixedChildren.map((child, i) => {
-          // NOTE: list block data is an array of data entries per list item
-          const dataEntry = blockProps.data.length > i ? blockProps.data[i] : {};
-          return withTextAlignment(
-            <li className={mergedStyles[`${className}List`]} key={blockProps.keys[i]}>
-              <p className={mergedStyles.elementSpacing}>
-                {child}
-              </p>
-            </li>,
-            dataEntry, mergedStyles, textDirection);
-        })}
-      </List>
-    );
-  };
-
-const getUnstyledBlocks = (mergedStyles, textDirection) =>
-  (children, blockProps) =>
-    children.map((child, i) => {
-      if (!isEmptyBlock(child)) {
+const getList = (ordered, mergedStyles, textDirection) => (children, blockProps) => {
+  const fixedChildren = children.map(child => (child.length ? child : [' ']));
+  const className = ordered ? 'ordered' : 'unordered';
+  const containerClassName = mergedStyles[`${className}ListContainer`];
+  return (
+    <List key={blockProps.keys[0]} keys={blockProps.keys} depth={blockProps.depth} ordered={ordered} className={containerClassName}>
+      {fixedChildren.map((child, i) => {
+        // NOTE: list block data is an array of data entries per list item
+        const dataEntry = blockProps.data.length > i ? blockProps.data[i] : {};
         return withTextAlignment(
-          <p className={mergedStyles.text} key={blockProps.keys[i]}>{child}</p>,
-          blockProps.data[i],
+          <li className={mergedStyles[`${className}List`]} key={blockProps.keys[i]}>
+            <p className={mergedStyles.elementSpacing}>{child}</p>
+          </li>,
+          dataEntry,
           mergedStyles,
           textDirection
         );
-      } else {
-        return <div className={mergedStyles.text} />;
-      }
-    });
+      })}
+    </List>
+  );
+};
+
+const getUnstyledBlocks = (mergedStyles, textDirection) => (children, blockProps) =>
+  children.map((child, i) => {
+    if (!isEmptyBlock(child)) {
+      return withTextAlignment(
+        <p className={mergedStyles.text} key={blockProps.keys[i]}>
+          {child}
+        </p>,
+        blockProps.data[i],
+        mergedStyles,
+        textDirection
+      );
+    } else {
+      return <div className={mergedStyles.text} />;
+    }
+  });
 
 const getBlocks = (mergedStyles, textDirection) => {
   return {
     unstyled: getUnstyledBlocks(mergedStyles, textDirection),
-    blockquote: (children, blockProps) => children.map((child, i) =>
-      withTextAlignment(<blockquote className={mergedStyles.quote} key={blockProps.keys[i]}><div>{child}</div></blockquote>,
-        blockProps.data[i], mergedStyles, textDirection)),
-    'header-one': (children, blockProps) => children.map((child, i) =>
-      withTextAlignment(<h1 className={mergedStyles.headerOne} key={blockProps.keys[i]}>{child}</h1>,
-        blockProps.data[i], mergedStyles, textDirection)),
-    'header-two': (children, blockProps) => children.map((child, i) =>
-      withTextAlignment(<h2 className={mergedStyles.headerTwo} key={blockProps.keys[i]}>{child}</h2>,
-        blockProps.data[i], mergedStyles, textDirection)),
-    'header-three': (children, blockProps) => children.map((child, i) =>
-      withTextAlignment(<h3 className={mergedStyles.headerThree} key={blockProps.keys[i]}>{child}</h3>,
-        blockProps.data[i], mergedStyles, textDirection)),
-    'code-block': (children, blockProps) => children.map((child, i) =>
-      withTextAlignment(<pre key={blockProps.keys[i]} className={mergedStyles.codeBlock}>{child}</pre>,
-        blockProps.data[i], mergedStyles, textDirection)),
+    blockquote: (children, blockProps) =>
+      children.map((child, i) =>
+        withTextAlignment(
+          <blockquote className={mergedStyles.quote} key={blockProps.keys[i]}>
+            <div>{child}</div>
+          </blockquote>,
+          blockProps.data[i],
+          mergedStyles,
+          textDirection
+        )
+      ),
+    'header-one': (children, blockProps) =>
+      children.map((child, i) =>
+        withTextAlignment(
+          <h1 className={mergedStyles.headerOne} key={blockProps.keys[i]}>
+            {child}
+          </h1>,
+          blockProps.data[i],
+          mergedStyles,
+          textDirection
+        )
+      ),
+    'header-two': (children, blockProps) =>
+      children.map((child, i) =>
+        withTextAlignment(
+          <h2 className={mergedStyles.headerTwo} key={blockProps.keys[i]}>
+            {child}
+          </h2>,
+          blockProps.data[i],
+          mergedStyles,
+          textDirection
+        )
+      ),
+    'header-three': (children, blockProps) =>
+      children.map((child, i) =>
+        withTextAlignment(
+          <h3 className={mergedStyles.headerThree} key={blockProps.keys[i]}>
+            {child}
+          </h3>,
+          blockProps.data[i],
+          mergedStyles,
+          textDirection
+        )
+      ),
+    'code-block': (children, blockProps) =>
+      children.map((child, i) =>
+        withTextAlignment(
+          <pre key={blockProps.keys[i]} className={mergedStyles.codeBlock}>
+            {child}
+          </pre>,
+          blockProps.data[i],
+          mergedStyles,
+          textDirection
+        )
+      ),
     'unordered-list-item': getList(false, mergedStyles, textDirection),
     'ordered-list-item': getList(true, mergedStyles, textDirection),
   };
 };
 
 const getEntities = (typeMap, pluginProps) => ({
-  ...getPluginsViewer(typeMap, pluginProps)
+  ...getPluginsViewer(typeMap, pluginProps),
 });
 
 const combineTypeMappers = mappers => {
@@ -108,7 +154,7 @@ const combineTypeMappers = mappers => {
   return mappers.reduce((map, mapper) => Object.assign(map, mapper()), {});
 };
 
-const isEmptyRaw = raw => (!raw || !raw.blocks || (raw.blocks.length === 1 && raw.blocks[0].text === ''));
+const isEmptyRaw = raw => !raw || !raw.blocks || (raw.blocks.length === 1 && raw.blocks[0].text === '');
 
 const options = {
   cleanup: {
@@ -153,7 +199,6 @@ const Preview = ({ raw, typeMappers, theme, isMobile, decorators, anchorTarget, 
 
   return (
     <div className={className}>
-      {isEmpty && <div>There is nothing to render...</div>}
       {!isEmpty &&
         redraft(
           augmentRaw(raw),
@@ -164,8 +209,7 @@ const Preview = ({ raw, typeMappers, theme, isMobile, decorators, anchorTarget, 
             decorators,
           },
           options
-        )
-      }
+        )}
     </div>
   );
 };
@@ -189,7 +233,7 @@ Preview.propTypes = {
       PropTypes.shape({
         component: PropTypes.func.isRequired,
         strategy: PropTypes.func.isRequired,
-      })
+      }),
     ])
   ),
   anchorTarget: PropTypes.string,

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  trailingComma: 'es5',
+  printWidth: 150,
+  singleQuote: true,
+  jsxSingleQuote: true,
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,8 +5,6 @@ import resolve from 'rollup-plugin-node-resolve';
 import builtins from 'rollup-plugin-node-builtins';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
-import { terser as uglify } from 'rollup-plugin-terser';
-import visualizer from 'rollup-plugin-visualizer';
 import json from 'rollup-plugin-json';
 import postcss from 'rollup-plugin-postcss';
 import postcssURL from 'postcss-url';
@@ -102,6 +100,14 @@ const plugins = [
 ];
 
 if (process.env.NODE_ENV !== 'development') {
+  const replace = require('rollup-plugin-replace');
+  plugins.push(
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production')
+    })
+  );
+
+  const uglify = require('rollup-plugin-terser').terser;
   plugins.push(
     uglify({
       mangle: false,
@@ -114,6 +120,7 @@ if (process.env.NODE_ENV !== 'development') {
 }
 
 if (process.env.MODULE_ANALYZE) {
+  const visualizer = require('rollup-plugin-visualizer');
   plugins.push(
     visualizer({
       sourcemaps: true,

--- a/scripts/deployExamples.js
+++ b/scripts/deployExamples.js
@@ -52,8 +52,8 @@ async function deployExamples(examples) {
 
   for (const example of examples) {
     console.log(chalk.blue(`\nDeploying ${example.name} example...`));
-    // bootstrap(example);
-    // build(example);
+    bootstrap(example);
+    build(example);
     publish(example);
   }
 }


### PR DESCRIPTION
Sometimes data can have incorrect shape and then plugins can crash causing all of the app to crash.
It's better to show nothing for that particular plugin and continue rendering rest of the app.

Example case: https://jira.wixpress.com/browse/FRM-479