### PR TITLE
move wnpm-ci to be a devDependency

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -49,8 +49,7 @@
     "react-click-outside": "github:tj/react-click-outside",
     "react-i18next": "^7.6.1",
     "react-measure": "^2.0.2",
-    "wix-rich-content-common": "^2.0.1",
-    "wnpm-ci": "latest"
+    "wix-rich-content-common": "^2.0.1"
   },
   "peerDependencies": {
     "@babel/runtime": "7.2.0",
@@ -72,7 +71,8 @@
     "react": "15.5.4",
     "react-dom": "15.5.4",
     "react-test-renderer": "^15.6.1",
-    "rollup": "^1.1.0"
+    "rollup": "^1.1.0",
+    "wnpm-ci": "latest"
   },
   "unpkg": true,
   "publishConfig": {


### PR DESCRIPTION
wnpm-ci is currently a `dependency`.

It should be listed as a `devDependency`, so other people that list this package in their dependencies won't necessarily get it.
