### PR TITLE
[*] configure dotenv for rollup so classnames are not lost in development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,14 +70,14 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
-			"integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+			"integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.0",
+				"@babel/types": "^7.3.4",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.11",
 				"source-map": "^0.5.0",
 				"trim-right": "^1.0.1"
 			}
@@ -123,16 +123,17 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.0.tgz",
-			"integrity": "sha512-DUsQNS2CGLZZ7I3W3fvh0YpPDd6BuWJlDl+qmZZpABZHza2ErE3LxtEzLJFHFC1ZwtlAXvHhbFYbtM5o5B0WBw==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz",
+			"integrity": "sha512-uFpzw6L2omjibjxa8VGZsJUPL5wJH0zzGKpoz0ccBkzIa6C8kWNUbiBmQ0rgOKWlHJ6qzmfa6lTiGchiV8SC+g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.2.3"
+				"@babel/helper-replace-supers": "^7.3.4",
+				"@babel/helper-split-export-declaration": "^7.0.0"
 			}
 		},
 		"@babel/helper-define-map": {
@@ -255,15 +256,15 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
-			"integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz",
+			"integrity": "sha512-pvObL9WVf2ADs+ePg0jrqlhHoxRXlOa+SHRHzAXIz2xkYuOHfGl+fKxPMaS4Fq+uje8JQPobnertBBvyrWnQ1A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.2.3",
-				"@babel/types": "^7.0.0"
+				"@babel/traverse": "^7.3.4",
+				"@babel/types": "^7.3.4"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -320,9 +321,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
-			"integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+			"integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
 			"dev": true
 		},
 		"@babel/plugin-external-helpers": {
@@ -366,9 +367,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.1.tgz",
-			"integrity": "sha512-Nmmv1+3LqxJu/V5jU9vJmxR/KIRWFk2qLHmbB56yRRRFhlaSuOVXscX3gUmhaKgUhzA3otOHVubbIEVYsZ0eZg==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz",
+			"integrity": "sha512-j7VQmbbkA+qrzNqbKHrBsW3ddFnOeva6wzSe/zB7T+xaxGc+RCpwo44wCmRixAIGRoIpmVgvzFzNJqQcO3/9RA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -451,9 +452,9 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
-			"integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.3.4.tgz",
+			"integrity": "sha512-Y7nCzv2fw/jEZ9f678MuKdMo99MFDJMT/PvD9LisrR5JDFcJH6vYeH6RnjVt3p5tceyGRvTtEN0VOlU+rgHZjA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -471,19 +472,19 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz",
-			"integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz",
+			"integrity": "sha512-blRr2O8IOZLAOJklXLV4WhcEzpYafYQKSGT3+R26lWG41u/FODJuBggehtOwilVAcFu393v3OFj+HmaE6tVjhA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz",
-			"integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.4.tgz",
+			"integrity": "sha512-J9fAvCFBkXEvBimgYxCjvaVDzL6thk0j0dBvCeZmIUDBwyt+nv6HfbImsSrWsYXfDNDivyANgJlFXDUWRTZBuA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
@@ -491,7 +492,7 @@
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/helper-replace-supers": "^7.3.4",
 				"@babel/helper-split-export-declaration": "^7.0.0",
 				"globals": "^11.1.0"
 			}
@@ -506,9 +507,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.2.0.tgz",
-			"integrity": "sha512-coVO2Ayv7g0qdDbrNiadE4bU7lvCd9H539m2gMknyVjjMdwF/iCOM7R+E8PkntoqLkltO0rk+3axhpp/0v68VQ==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
+			"integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -594,9 +595,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz",
-			"integrity": "sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.3.4.tgz",
+			"integrity": "sha512-VZ4+jlGOF36S7TjKs8g4ojp4MEI+ebCQZdswWb/T9I4X84j8OtFAyjXjt/M16iIm5RIZn0UMQgg/VgIwo/87vw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.0.0",
@@ -633,9 +634,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz",
-			"integrity": "sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.3.3.tgz",
+			"integrity": "sha512-IrIP25VvXWu/VlBWTpsjGptpomtIkYrN/3aDp4UKm7xK6UxZY88kcJ1UwETbzHAlwN21MnNfwlar0u8y3KpiXw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-call-delegate": "^7.1.0",
@@ -684,12 +685,12 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
-			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.3.4.tgz",
+			"integrity": "sha512-hvJg8EReQvXT6G9H2MvNPXkv9zK36Vxa1+csAVTpE1J3j0zlHplw76uudEbJxgvqZzAq9Yh45FLD4pk5mKRFQA==",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "^0.13.3"
+				"regenerator-transform": "^0.13.4"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
@@ -845,20 +846,20 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+			"integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.2.2",
+				"@babel/generator": "^7.3.4",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/parser": "^7.2.3",
-				"@babel/types": "^7.2.2",
+				"@babel/parser": "^7.3.4",
+				"@babel/types": "^7.3.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			},
 			"dependencies": {
 				"debug": {
@@ -879,67 +880,69 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
-			"integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+			"integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.11",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@lerna/add": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.10.6.tgz",
-			"integrity": "sha512-FxQ5Bmyb5fF+3BQiNffM6cTeGCrl4uaAuGvxFIWF6Pgz6U14tUc1e16xgKDvVb1CurzJgIV5sLOT5xmCOqv1kA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.13.1.tgz",
+			"integrity": "sha512-cXk42YbuhzEnADCK8Qte5laC9Qo03eJLVnr0qKY85jQUM/T4URe3IIUemqpg0CpVATrB+Vz+iNdeqw9ng1iALw==",
 			"dev": true,
 			"requires": {
-				"@lerna/bootstrap": "3.10.6",
-				"@lerna/command": "3.10.6",
-				"@lerna/filter-options": "3.10.6",
-				"@lerna/npm-conf": "3.7.0",
-				"@lerna/validation-error": "3.6.0",
+				"@lerna/bootstrap": "3.13.1",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/npm-conf": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
 				"dedent": "^0.7.0",
-				"libnpm": "^2.0.1",
+				"npm-package-arg": "^6.1.0",
 				"p-map": "^1.2.0",
+				"pacote": "^9.5.0",
 				"semver": "^5.5.0"
 			}
 		},
 		"@lerna/batch-packages": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.10.6.tgz",
-			"integrity": "sha512-sInr3ZQJFMh9Zq+ZUoVjX8R67j9ViRkVy0uEMsOfG+jZlXj1lRPRMPRiRgU0jXSYEwCdwuAB5pTd9tTx0VCJUw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.13.0.tgz",
+			"integrity": "sha512-TgLBTZ7ZlqilGnzJ3xh1KdAHcySfHytgNRTdG9YomfriTU6kVfp1HrXxKJYVGs7ClPUNt2CTFEOkw0tMBronjw==",
 			"dev": true,
 			"requires": {
-				"@lerna/package-graph": "3.10.6",
-				"@lerna/validation-error": "3.6.0",
-				"libnpm": "^2.0.1"
+				"@lerna/package-graph": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/bootstrap": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.10.6.tgz",
-			"integrity": "sha512-qbGjAxRpV/eiI9CboUIpsPPGpSogs8mN2/iDaAUBTaWVFVz/YyU64nui84Gll0kbdaHOyPput+kk2S8NCSCCdg==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.13.1.tgz",
+			"integrity": "sha512-mKdi5Ds5f82PZwEFyB9/W60I3iELobi1i87sTeVrbJh/um7GvqpSPy7kG/JPxyOdMpB2njX6LiJgw+7b6BEPWw==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "3.10.6",
-				"@lerna/command": "3.10.6",
-				"@lerna/filter-options": "3.10.6",
-				"@lerna/has-npm-version": "3.10.0",
-				"@lerna/npm-install": "3.10.0",
-				"@lerna/package-graph": "3.10.6",
-				"@lerna/pulse-till-done": "3.7.1",
-				"@lerna/rimraf-dir": "3.10.0",
-				"@lerna/run-lifecycle": "3.10.5",
-				"@lerna/run-parallel-batches": "3.0.0",
-				"@lerna/symlink-binary": "3.10.0",
-				"@lerna/symlink-dependencies": "3.10.0",
-				"@lerna/validation-error": "3.6.0",
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/has-npm-version": "3.13.0",
+				"@lerna/npm-install": "3.13.0",
+				"@lerna/package-graph": "3.13.0",
+				"@lerna/pulse-till-done": "3.13.0",
+				"@lerna/rimraf-dir": "3.13.0",
+				"@lerna/run-lifecycle": "3.13.0",
+				"@lerna/run-parallel-batches": "3.13.0",
+				"@lerna/symlink-binary": "3.13.0",
+				"@lerna/symlink-dependencies": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
 				"dedent": "^0.7.0",
 				"get-port": "^3.2.0",
-				"libnpm": "^2.0.1",
 				"multimatch": "^2.1.0",
+				"npm-package-arg": "^6.1.0",
+				"npmlog": "^4.1.2",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
 				"p-map-series": "^1.0.0",
@@ -949,32 +952,32 @@
 			}
 		},
 		"@lerna/changed": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.10.6.tgz",
-			"integrity": "sha512-nZDVq/sKdhgoAg1BVnpqjqUUz5+zedG+AnU+6mjEN2f23YVtRCsW55N4I9eEdW2pxXUaCY85Hj/HPSA74BYaFg==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.1.tgz",
+			"integrity": "sha512-BRXitEJGOkoudbxEewW7WhjkLxFD+tTk4PrYpHLyCBk63pNTWtQLRE6dc1hqwh4emwyGncoyW6RgXfLgMZgryw==",
 			"dev": true,
 			"requires": {
-				"@lerna/collect-updates": "3.10.1",
-				"@lerna/command": "3.10.6",
-				"@lerna/listable": "3.10.6",
-				"@lerna/output": "3.6.0",
-				"@lerna/version": "3.10.6"
+				"@lerna/collect-updates": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/listable": "3.13.0",
+				"@lerna/output": "3.13.0",
+				"@lerna/version": "3.13.1"
 			}
 		},
 		"@lerna/check-working-tree": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.10.0.tgz",
-			"integrity": "sha512-NdIPhDgEtGHfeGjB9F0oAoPLywgMpjnJhLLwTNQkelDHo2xNAVpG8kV+A2UJ+cU5UXCZA4RZFxKNmw86rO+Drw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.13.0.tgz",
+			"integrity": "sha512-dsdO15NXX5To+Q53SYeCrBEpiqv4m5VkaPZxbGQZNwoRen1MloXuqxSymJANQn+ZLEqarv5V56gydebeROPH5A==",
 			"dev": true,
 			"requires": {
-				"@lerna/describe-ref": "3.10.0",
-				"@lerna/validation-error": "3.6.0"
+				"@lerna/describe-ref": "3.13.0",
+				"@lerna/validation-error": "3.13.0"
 			}
 		},
 		"@lerna/child-process": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.3.0.tgz",
-			"integrity": "sha512-q2d/OPlNX/cBXB6Iz1932RFzOmOHq6ZzPjqebkINNaTojHWuuRpvJJY4Uz3NGpJ3kEtPDvBemkZqUBTSO5wb1g==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.0.tgz",
+			"integrity": "sha512-0iDS8y2jiEucD4fJHEzKoc8aQJgm7s+hG+0RmDNtfT0MM3n17pZnf5JOMtS1FJp+SEXOjMKQndyyaDIPFsnp6A==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.1",
@@ -983,30 +986,30 @@
 			}
 		},
 		"@lerna/clean": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.10.6.tgz",
-			"integrity": "sha512-MuL8HOwnyvVtr6GOiAN/Ofjbx+BJdCrtjrM1Uuh8FFnbnZTPVf+0MPxL2jVzPMo0PmoIrX3fvlwvzKNk/lH0Ug==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.13.1.tgz",
+			"integrity": "sha512-myGIaXv7RUO2qCFZXvx8SJeI+eN6y9SUD5zZ4/LvNogbOiEIlujC5lUAqK65rAHayQ9ltSa/yK6Xv510xhZXZQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.10.6",
-				"@lerna/filter-options": "3.10.6",
-				"@lerna/prompt": "3.6.0",
-				"@lerna/pulse-till-done": "3.7.1",
-				"@lerna/rimraf-dir": "3.10.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/prompt": "3.13.0",
+				"@lerna/pulse-till-done": "3.13.0",
+				"@lerna/rimraf-dir": "3.13.0",
 				"p-map": "^1.2.0",
 				"p-map-series": "^1.0.0",
 				"p-waterfall": "^1.0.0"
 			}
 		},
 		"@lerna/cli": {
-			"version": "3.10.7",
-			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.10.7.tgz",
-			"integrity": "sha512-yuoz/24mIfYit3neKqoE5NVs42Rj9A6A6SlkNPDfsy3v/Vh7SgYkU3cwiGyvwBGzIdhqL4/SWYo8H7YJLs0C+g==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
+			"integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
 			"dev": true,
 			"requires": {
-				"@lerna/global-options": "3.10.6",
+				"@lerna/global-options": "3.13.0",
 				"dedent": "^0.7.0",
-				"libnpm": "^2.0.1",
+				"npmlog": "^4.1.2",
 				"yargs": "^12.0.1"
 			},
 			"dependencies": {
@@ -1160,15 +1163,15 @@
 			}
 		},
 		"@lerna/collect-updates": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.10.1.tgz",
-			"integrity": "sha512-vb0wEJ8k63G+2CR/ud1WeVHNJ21Fs6Ew6lbdGZXnF4ZvaFWxWJZpoHeWwzjhMdJ75QdTzUaIhTG1hnH9faQNMw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.13.0.tgz",
+			"integrity": "sha512-uR3u6uTzrS1p46tHQ/mlHog/nRJGBqskTHYYJbgirujxm6FqNh7Do+I1Q/7zSee407G4lzsNxZdm8IL927HemQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"@lerna/describe-ref": "3.10.0",
-				"libnpm": "^2.0.1",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/describe-ref": "3.13.0",
 				"minimatch": "^3.0.4",
+				"npmlog": "^4.1.2",
 				"slash": "^1.0.0"
 			},
 			"dependencies": {
@@ -1181,21 +1184,21 @@
 			}
 		},
 		"@lerna/command": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.10.6.tgz",
-			"integrity": "sha512-jPZswMZXOpAaIuSF5hrz+eaWQzbDrvwbrkCoRJKfiAHx7URAkE6MQe9DeAnqrTKMqwfg0RciSrZLc8kWYfrzCQ==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.13.1.tgz",
+			"integrity": "sha512-SYWezxX+iheWvzRoHCrbs8v5zHPaxAx3kWvZhqi70vuGsdOVAWmaG4IvHLn11ztS+Vpd5PM+ztBWSbnykpLFKQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"@lerna/package-graph": "3.10.6",
-				"@lerna/project": "3.10.0",
-				"@lerna/validation-error": "3.6.0",
-				"@lerna/write-log-file": "3.6.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/package-graph": "3.13.0",
+				"@lerna/project": "3.13.1",
+				"@lerna/validation-error": "3.13.0",
+				"@lerna/write-log-file": "3.13.0",
 				"dedent": "^0.7.0",
 				"execa": "^1.0.0",
 				"is-ci": "^1.0.10",
-				"libnpm": "^2.0.1",
-				"lodash": "^4.17.5"
+				"lodash": "^4.17.5",
+				"npmlog": "^4.1.2"
 			},
 			"dependencies": {
 				"ci-info": {
@@ -1216,38 +1219,49 @@
 			}
 		},
 		"@lerna/conventional-commits": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.10.0.tgz",
-			"integrity": "sha512-8FvO0eR8g/tEgkb6eRVYaD39TsqMKsOXp17EV48jciciEqcrF/d1Ypu6ilK1GDp6R/1m2mbjt/b52a/qrO+xaw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.13.0.tgz",
+			"integrity": "sha512-BeAgcNXuocmLhPxnmKU2Vy8YkPd/Uo+vu2i/p3JGsUldzrPC8iF3IDxH7fuXpEFN2Nfogu7KHachd4tchtOppA==",
 			"dev": true,
 			"requires": {
-				"@lerna/validation-error": "3.6.0",
-				"conventional-changelog-angular": "^5.0.2",
-				"conventional-changelog-core": "^3.1.5",
+				"@lerna/validation-error": "3.13.0",
+				"conventional-changelog-angular": "^5.0.3",
+				"conventional-changelog-core": "^3.1.6",
 				"conventional-recommended-bump": "^4.0.4",
 				"fs-extra": "^7.0.0",
 				"get-stream": "^4.0.0",
-				"libnpm": "^2.0.1",
+				"npm-package-arg": "^6.1.0",
+				"npmlog": "^4.1.2",
+				"pify": "^3.0.0",
 				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"@lerna/create": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.10.6.tgz",
-			"integrity": "sha512-OddQtGBHM2/eJONggLWoTE6275XGbnJ6dIVF+fLsKS93o4GC6g+qcc6Y7lUWHm5bfpeOwNOVKwj0tvqBZ6MgoA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.13.1.tgz",
+			"integrity": "sha512-pLENMXgTkQuvKxAopjKeoLOv9fVUCnpTUD7aLrY5d95/1xqSZlnsOcQfUYcpMf3GpOvHc8ILmI5OXkPqjAf54g==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"@lerna/command": "3.10.6",
-				"@lerna/npm-conf": "3.7.0",
-				"@lerna/validation-error": "3.6.0",
-				"camelcase": "^4.1.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/npm-conf": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"camelcase": "^5.0.0",
 				"dedent": "^0.7.0",
 				"fs-extra": "^7.0.0",
 				"globby": "^8.0.1",
 				"init-package-json": "^1.10.3",
-				"libnpm": "^2.0.1",
+				"npm-package-arg": "^6.1.0",
 				"p-reduce": "^1.0.0",
+				"pacote": "^9.5.0",
 				"pify": "^3.0.0",
 				"semver": "^5.5.0",
 				"slash": "^1.0.0",
@@ -1256,12 +1270,6 @@
 				"whatwg-url": "^7.0.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
 				"dir-glob": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
@@ -1311,87 +1319,87 @@
 			}
 		},
 		"@lerna/create-symlink": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.6.0.tgz",
-			"integrity": "sha512-YG3lTb6zylvmGqKU+QYA3ylSnoLn+FyLH5XZmUsD0i85R884+EyJJeHx/zUk+yrL2ZwHS4RBUgJfC24fqzgPoA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.13.0.tgz",
+			"integrity": "sha512-PTvg3jAAJSAtLFoZDsuTMv1wTOC3XYIdtg54k7uxIHsP8Ztpt+vlilY/Cni0THAqEMHvfiToel76Xdta4TU21Q==",
 			"dev": true,
 			"requires": {
 				"cmd-shim": "^2.0.2",
 				"fs-extra": "^7.0.0",
-				"libnpm": "^2.0.1"
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/describe-ref": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.10.0.tgz",
-			"integrity": "sha512-fouh3FQS07QxJJp/mW8LkGnH0xMRAzpBlejtZaiRwfDkW2kd6EuHaj8I/2/p21Wsprcvuu4dqmyia2YS1xFb/w==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.0.tgz",
+			"integrity": "sha512-UJefF5mLxLae9I2Sbz5RLYGbqbikRuMqdgTam0MS5OhXnyuuKYBUpwBshCURNb1dPBXTQhSwc7+oUhORx8ojCg==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"libnpm": "^2.0.1"
+				"@lerna/child-process": "3.13.0",
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/diff": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.10.6.tgz",
-			"integrity": "sha512-0MqFhosjrqsIdXiKIu7t3CiJELqiU9mkjFBhYPB7JruAzpPwjMXJnC6/Ur5/7LXJYYVpqGQwZI9ZaZlOYJhhrw==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.13.1.tgz",
+			"integrity": "sha512-cKqmpONO57mdvxtp8e+l5+tjtmF04+7E+O0QEcLcNUAjC6UR2OSM77nwRCXDukou/1h72JtWs0jjcdYLwAmApg==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"@lerna/command": "3.10.6",
-				"@lerna/validation-error": "3.6.0",
-				"libnpm": "^2.0.1"
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/validation-error": "3.13.0",
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/exec": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.10.6.tgz",
-			"integrity": "sha512-cdHqaRBMYceJu8rZLO8b4ZeR27O+xKPHgzi13OOOfBJQjrTuacjMWyHgmpy8jWc/0f7QnTl4VsHks7VJ3UK+vw==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.13.1.tgz",
+			"integrity": "sha512-I34wEP9lrAqqM7tTXLDxv/6454WFzrnXDWpNDbiKQiZs6SIrOOjmm6I4FiQsx+rU3o9d+HkC6tcUJRN5mlJUgA==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "3.10.6",
-				"@lerna/child-process": "3.3.0",
-				"@lerna/command": "3.10.6",
-				"@lerna/filter-options": "3.10.6",
-				"@lerna/run-parallel-batches": "3.0.0",
-				"@lerna/validation-error": "3.6.0"
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/run-parallel-batches": "3.13.0",
+				"@lerna/validation-error": "3.13.0"
 			}
 		},
 		"@lerna/filter-options": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.10.6.tgz",
-			"integrity": "sha512-r/dQbqN+RGFKZNn+DyWehswFmAkny/fkdMB2sRM2YVe7zRTtSl95YxD9DtdYnpJTG/jbOVICS/L5QJakrI6SSw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.13.0.tgz",
+			"integrity": "sha512-SRp7DCo9zrf+7NkQxZMkeyO1GRN6GICoB9UcBAbXhLbWisT37Cx5/6+jh49gYB63d/0/WYHSEPMlheUrpv1Srw==",
 			"dev": true,
 			"requires": {
-				"@lerna/collect-updates": "3.10.1",
-				"@lerna/filter-packages": "3.10.0",
+				"@lerna/collect-updates": "3.13.0",
+				"@lerna/filter-packages": "3.13.0",
 				"dedent": "^0.7.0"
 			}
 		},
 		"@lerna/filter-packages": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.10.0.tgz",
-			"integrity": "sha512-3Acdj+jbany6LnQSuImU4ttcK5ULHSVug8Gh/EvwTewKCDpHAuoI3eyuzZOnSBdMvDOjE03uIESQK0dNNsn6Ow==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.13.0.tgz",
+			"integrity": "sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/validation-error": "3.6.0",
-				"libnpm": "^2.0.1",
-				"multimatch": "^2.1.0"
+				"@lerna/validation-error": "3.13.0",
+				"multimatch": "^2.1.0",
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/get-npm-exec-opts": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.6.0.tgz",
-			"integrity": "sha512-ruH6KuLlt75aCObXfUIdVJqmfVq7sgWGq5mXa05vc1MEqxTIiU23YiJdWzofQOOUOACaZkzZ4K4Nu7wXEg4Xgg==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz",
+			"integrity": "sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==",
 			"dev": true,
 			"requires": {
-				"libnpm": "^2.0.1"
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/get-packed": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.7.0.tgz",
-			"integrity": "sha512-yuFtjsUZIHjeIvIYQ/QuytC+FQcHwo3peB+yGBST2uWCLUCR5rx6knoQcPzbxdFDCuUb5IFccFGd3B1fHFg3RQ==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz",
+			"integrity": "sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==",
 			"dev": true,
 			"requires": {
 				"fs-extra": "^7.0.0",
@@ -1431,60 +1439,73 @@
 				}
 			}
 		},
+		"@lerna/github-client": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.1.tgz",
+			"integrity": "sha512-iPLUp8FFoAKGURksYEYZzfuo9TRA+NepVlseRXFaWlmy36dCQN20AciINpoXiXGoHcEUHXUKHQvY3ARFdMlf3w==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@octokit/plugin-enterprise-rest": "^2.1.1",
+				"@octokit/rest": "^16.16.0",
+				"git-url-parse": "^11.1.2",
+				"npmlog": "^4.1.2"
+			}
+		},
 		"@lerna/global-options": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.10.6.tgz",
-			"integrity": "sha512-k5Xkq1M/uREFC2R9uwN5gcvIgjj4iOXo0YyeEXCMWBiW3j2GL9xN4d1MmAIcrYlAzVYh6kLlWaFWl/rNIneHIw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz",
+			"integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==",
 			"dev": true
 		},
 		"@lerna/has-npm-version": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.10.0.tgz",
-			"integrity": "sha512-N4RRYxGeivuaKgPDzrhkQOQs1Sg4tOnxnEe3akfqu1wDA4Ng5V6Y2uW3DbkAjFL3aNJhWF5Vbf7sBsGtfgDQ8w==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.0.tgz",
+			"integrity": "sha512-Oqu7DGLnrMENPm+bPFGOHnqxK8lCnuYr6bk3g/CoNn8/U0qgFvHcq6Iv8/Z04TsvleX+3/RgauSD2kMfRmbypg==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
+				"@lerna/child-process": "3.13.0",
 				"semver": "^5.5.0"
 			}
 		},
 		"@lerna/import": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.10.6.tgz",
-			"integrity": "sha512-LlGxhfDhovoNoBJLF3PYd3j/G2GFTnfLh0V38+hBQ6lomMNJbjkACfiLVomQxPWWpYLk0GTlpWYR8YGv6L7Ifw==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.13.1.tgz",
+			"integrity": "sha512-A1Vk1siYx1XkRl6w+zkaA0iptV5TIynVlHPR9S7NY0XAfhykjztYVvwtxarlh6+VcNrO9We6if0+FXCrfDEoIg==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"@lerna/command": "3.10.6",
-				"@lerna/prompt": "3.6.0",
-				"@lerna/pulse-till-done": "3.7.1",
-				"@lerna/validation-error": "3.6.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/prompt": "3.13.0",
+				"@lerna/pulse-till-done": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
 				"dedent": "^0.7.0",
 				"fs-extra": "^7.0.0",
 				"p-map-series": "^1.0.0"
 			}
 		},
 		"@lerna/init": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.10.6.tgz",
-			"integrity": "sha512-RIlEx+ofWLYRNjxCkkV3G0XQPM+/KA5RXRDb5wKQLYO1f+tZAaHoUh8fHDIvxGf/ohY/OIjYYGSsU+ysimfwiQ==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.13.1.tgz",
+			"integrity": "sha512-M59WACqim8WkH5FQEGOCEZ89NDxCKBfFTx4ZD5ig3LkGyJ8RdcJq5KEfpW/aESuRE9JrZLzVr0IjKbZSxzwEMA==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"@lerna/command": "3.10.6",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
 				"fs-extra": "^7.0.0",
 				"p-map": "^1.2.0",
 				"write-json-file": "^2.3.0"
 			}
 		},
 		"@lerna/link": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.10.6.tgz",
-			"integrity": "sha512-dwD6qftRWitgLDYbqtDrgO7c8uF5C0fHVew5M6gU5m9tBJidqd7cDwHv/bXboLEI63U7tt5y6LY+wEpYUFsBRw==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.13.1.tgz",
+			"integrity": "sha512-N3h3Fj1dcea+1RaAoAdy4g2m3fvU7m89HoUn5X/Zcw5n2kPoK8kTO+NfhNAatfRV8VtMXst8vbNrWQQtfm0FFw==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.10.6",
-				"@lerna/package-graph": "3.10.6",
-				"@lerna/symlink-dependencies": "3.10.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/package-graph": "3.13.0",
+				"@lerna/symlink-dependencies": "3.13.0",
 				"p-map": "^1.2.0",
 				"slash": "^1.0.0"
 			},
@@ -1498,44 +1519,44 @@
 			}
 		},
 		"@lerna/list": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.10.6.tgz",
-			"integrity": "sha512-3ElQBj2dOB4uUkpsjC1bxdeZwEzRBuV1pBBs5E1LncwsZf7D9D99Z32fuZsDaCHpEMgHAD4/j8juI3/7m5dkaQ==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.13.1.tgz",
+			"integrity": "sha512-635iRbdgd9gNvYLLIbYdQCQLr+HioM5FGJLFS0g3DPGygr6iDR8KS47hzCRGH91LU9NcM1mD1RoT/AChF+QbiA==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.10.6",
-				"@lerna/filter-options": "3.10.6",
-				"@lerna/listable": "3.10.6",
-				"@lerna/output": "3.6.0"
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/listable": "3.13.0",
+				"@lerna/output": "3.13.0"
 			}
 		},
 		"@lerna/listable": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.10.6.tgz",
-			"integrity": "sha512-F7ZuvesSgeuMiJf99eOum5p1MQGQStykcmHH1ek+LQRMiGGF1o3PkBxPvHTZBADGOFarek8bFA5TVmRAMX7NIw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.13.0.tgz",
+			"integrity": "sha512-liYJ/WBUYP4N4MnSVZuLUgfa/jy3BZ02/1Om7xUY09xGVSuNVNEeB8uZUMSC+nHqFHIsMPZ8QK9HnmZb1E/eTA==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "3.10.6",
+				"@lerna/batch-packages": "3.13.0",
 				"chalk": "^2.3.1",
 				"columnify": "^1.5.4"
 			}
 		},
 		"@lerna/log-packed": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.6.0.tgz",
-			"integrity": "sha512-T/J41zMkzpWB5nbiTRS5PmYTFn74mJXe6RQA2qhkdLi0UqnTp97Pux1loz3jsJf2yJtiQUnyMM7KuKIAge0Vlw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.13.0.tgz",
+			"integrity": "sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==",
 			"dev": true,
 			"requires": {
 				"byte-size": "^4.0.3",
 				"columnify": "^1.5.4",
 				"has-unicode": "^2.0.1",
-				"libnpm": "^2.0.1"
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/npm-conf": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.7.0.tgz",
-			"integrity": "sha512-+WSMDfPKcKzMfqq283ydz9RRpOU6p9wfx0wy4hVSUY/6YUpsyuk8SShjcRtY8zTM5AOrxvFBuuV90H4YpZ5+Ng==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz",
+			"integrity": "sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==",
 			"dev": true,
 			"requires": {
 				"config-chain": "^1.1.11",
@@ -1551,73 +1572,87 @@
 			}
 		},
 		"@lerna/npm-dist-tag": {
-			"version": "3.8.5",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.8.5.tgz",
-			"integrity": "sha512-VO57yKTB4NC2LZuTd4w0LmlRpoFm/gejQ1gqqLGzSJuSZaBXmieElFovzl21S07cqiy7FNVdz75x7/a6WCZ6XA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.13.0.tgz",
+			"integrity": "sha512-mcuhw34JhSRFrbPn0vedbvgBTvveG52bR2lVE3M3tfE8gmR/cKS/EJFO4AUhfRKGCTFn9rjaSEzlFGYV87pemQ==",
 			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1",
-				"libnpm": "^2.0.1"
+				"npm-package-arg": "^6.1.0",
+				"npm-registry-fetch": "^3.9.0",
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/npm-install": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.10.0.tgz",
-			"integrity": "sha512-/6/XyLY9/4jaMPBOVYUr4wZxQURIfwoELY0qCQ8gZ5zv4cOiFiiCUxZ0i4fxqFtD7nJ084zq1DsZW0aH0CIWYw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.0.tgz",
+			"integrity": "sha512-qNyfts//isYQxore6fsPorNYJmPVKZ6tOThSH97tP0aV91zGMtrYRqlAoUnDwDdAjHPYEM16hNujg2wRmsqqIw==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"@lerna/get-npm-exec-opts": "3.6.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/get-npm-exec-opts": "3.13.0",
 				"fs-extra": "^7.0.0",
-				"libnpm": "^2.0.1",
+				"npm-package-arg": "^6.1.0",
+				"npmlog": "^4.1.2",
 				"signal-exit": "^3.0.2",
 				"write-pkg": "^3.1.0"
 			}
 		},
 		"@lerna/npm-publish": {
-			"version": "3.10.7",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.10.7.tgz",
-			"integrity": "sha512-oU3/Q+eHC1fRjh7bk6Nn4tRD1OLR6XZVs3v+UWMWMrF4hVSV61pxcP5tpeI1n4gDQjSgh7seI4EzKVJe/WfraA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.13.0.tgz",
+			"integrity": "sha512-y4WO0XTaf9gNRkI7as6P2ItVDOxmYHwYto357fjybcnfXgMqEA94c3GJ++jU41j0A9vnmYC6/XxpTd9sVmH9tA==",
 			"dev": true,
 			"requires": {
-				"@lerna/run-lifecycle": "3.10.5",
+				"@lerna/run-lifecycle": "3.13.0",
 				"figgy-pudding": "^3.5.1",
 				"fs-extra": "^7.0.0",
-				"libnpm": "^2.0.1"
+				"libnpmpublish": "^1.1.1",
+				"npmlog": "^4.1.2",
+				"pify": "^3.0.0",
+				"read-package-json": "^2.0.13"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"@lerna/npm-run-script": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.10.0.tgz",
-			"integrity": "sha512-c21tBXLF1Wje4tx/Td9jKIMrlZo/8QQiyyadjdKpwyyo7orSMsVNXGyJwvZ4JVVDcwC3GPU6HQvkt63v7rcyaw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.0.tgz",
+			"integrity": "sha512-hiL3/VeVp+NFatBjkGN8mUdX24EfZx9rQlSie0CMgtjc7iZrtd0jCguLomSCRHYjJuvqgbp+LLYo7nHVykfkaQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"@lerna/get-npm-exec-opts": "3.6.0",
-				"libnpm": "^2.0.1"
+				"@lerna/child-process": "3.13.0",
+				"@lerna/get-npm-exec-opts": "3.13.0",
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/output": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.6.0.tgz",
-			"integrity": "sha512-9sjQouf6p7VQtVCRnzoTGlZyURd48i3ha3WBHC/UBJnHZFuXMqWVPKNuvnMf2kRXDyoQD+2mNywpmEJg5jOnRg==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz",
+			"integrity": "sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==",
 			"dev": true,
 			"requires": {
-				"libnpm": "^2.0.1"
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/pack-directory": {
-			"version": "3.10.5",
-			"resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.10.5.tgz",
-			"integrity": "sha512-Ulj24L9XdgjJIxBr6ZjRJEoBULVH3c10lqunUdW41bswXhzhirRtQIxv0+5shngNjDwgMmJfOBcuCVKPSez4tg==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.13.1.tgz",
+			"integrity": "sha512-kXnyqrkQbCIZOf1054N88+8h0ItC7tUN5v9ca/aWpx298gsURpxUx/1TIKqijL5TOnHMyIkj0YJmnH/PyBVLKA==",
 			"dev": true,
 			"requires": {
-				"@lerna/get-packed": "3.7.0",
-				"@lerna/package": "3.7.2",
-				"@lerna/run-lifecycle": "3.10.5",
+				"@lerna/get-packed": "3.13.0",
+				"@lerna/package": "3.13.0",
+				"@lerna/run-lifecycle": "3.13.0",
 				"figgy-pudding": "^3.5.1",
-				"libnpm": "^2.0.1",
-				"npm-packlist": "^1.1.12",
+				"npm-packlist": "^1.4.1",
+				"npmlog": "^4.1.2",
 				"tar": "^4.4.8",
 				"temp-write": "^3.4.0"
 			},
@@ -1646,13 +1681,13 @@
 			}
 		},
 		"@lerna/package": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.7.2.tgz",
-			"integrity": "sha512-8A5hN2CekM1a0Ix4VUO/g+REo+MsnXb8lnQ0bGjr1YGWzSL5NxYJ0Z9+0pwTfDpvRDYlFYO0rMVwBUW44b4dUw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.13.0.tgz",
+			"integrity": "sha512-kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==",
 			"dev": true,
 			"requires": {
-				"libnpm": "^2.0.1",
 				"load-json-file": "^4.0.0",
+				"npm-package-arg": "^6.1.0",
 				"write-pkg": "^3.1.0"
 			},
 			"dependencies": {
@@ -1683,31 +1718,31 @@
 			}
 		},
 		"@lerna/package-graph": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.10.6.tgz",
-			"integrity": "sha512-mpIOJbhi+xLqT9BcUrLVD4We8WUdousQf/QndbEWl8DWAW1ethtRHVsCm9ufdBB3F9nj4PH/hqnDWWwqE+rS4w==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.13.0.tgz",
+			"integrity": "sha512-3mRF1zuqFE1HEFmMMAIggXy+f+9cvHhW/jzaPEVyrPNLKsyfJQtpTNzeI04nfRvbAh+Gd2aNksvaW/w3xGJnnw==",
 			"dev": true,
 			"requires": {
-				"@lerna/validation-error": "3.6.0",
-				"libnpm": "^2.0.1",
+				"@lerna/validation-error": "3.13.0",
+				"npm-package-arg": "^6.1.0",
 				"semver": "^5.5.0"
 			}
 		},
 		"@lerna/project": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.10.0.tgz",
-			"integrity": "sha512-9QRl8aGHuyU4zVEELQmNPnJTlS7XHqX7w9I9isCXdnilKc2R0MyvUs21lj6Yyt6xTuQnqD158TR9tbS4QufYQQ==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.13.1.tgz",
+			"integrity": "sha512-/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/package": "3.7.2",
-				"@lerna/validation-error": "3.6.0",
-				"cosmiconfig": "^5.0.2",
+				"@lerna/package": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"cosmiconfig": "^5.1.0",
 				"dedent": "^0.7.0",
 				"dot-prop": "^4.2.0",
 				"glob-parent": "^3.1.0",
 				"globby": "^8.0.1",
-				"libnpm": "^2.0.1",
 				"load-json-file": "^4.0.0",
+				"npmlog": "^4.1.2",
 				"p-map": "^1.2.0",
 				"resolve-from": "^4.0.0",
 				"write-json-file": "^2.3.0"
@@ -1786,13 +1821,13 @@
 			}
 		},
 		"@lerna/prompt": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.6.0.tgz",
-			"integrity": "sha512-nyAjPMolJ/ZRAAVcXrUH89C4n1SiWvLh4xWNvWYKLcf3PI5yges35sDFP/HYrM4+cEbkNFuJCRq6CxaET4PRsg==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz",
+			"integrity": "sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==",
 			"dev": true,
 			"requires": {
 				"inquirer": "^6.2.0",
-				"libnpm": "^2.0.1"
+				"npmlog": "^4.1.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -1886,103 +1921,108 @@
 			}
 		},
 		"@lerna/publish": {
-			"version": "3.10.7",
-			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.10.7.tgz",
-			"integrity": "sha512-Qd8pml2l9s6GIvNX1pTnia+Ddjsm9LF3pRRoOQeugAdv2IJNf45c/83AAEyE9M2ShG5VjgxEITNW4Lg49zipjQ==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.1.tgz",
+			"integrity": "sha512-KhCJ9UDx76HWCF03i5TD7z5lX+2yklHh5SyO8eDaLptgdLDQ0Z78lfGj3JhewHU2l46FztmqxL/ss0IkWHDL+g==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "3.10.6",
-				"@lerna/check-working-tree": "3.10.0",
-				"@lerna/child-process": "3.3.0",
-				"@lerna/collect-updates": "3.10.1",
-				"@lerna/command": "3.10.6",
-				"@lerna/describe-ref": "3.10.0",
-				"@lerna/log-packed": "3.6.0",
-				"@lerna/npm-conf": "3.7.0",
-				"@lerna/npm-dist-tag": "3.8.5",
-				"@lerna/npm-publish": "3.10.7",
-				"@lerna/output": "3.6.0",
-				"@lerna/pack-directory": "3.10.5",
-				"@lerna/prompt": "3.6.0",
-				"@lerna/pulse-till-done": "3.7.1",
-				"@lerna/run-lifecycle": "3.10.5",
-				"@lerna/run-parallel-batches": "3.0.0",
-				"@lerna/validation-error": "3.6.0",
-				"@lerna/version": "3.10.6",
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/check-working-tree": "3.13.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/collect-updates": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/describe-ref": "3.13.0",
+				"@lerna/log-packed": "3.13.0",
+				"@lerna/npm-conf": "3.13.0",
+				"@lerna/npm-dist-tag": "3.13.0",
+				"@lerna/npm-publish": "3.13.0",
+				"@lerna/output": "3.13.0",
+				"@lerna/pack-directory": "3.13.1",
+				"@lerna/prompt": "3.13.0",
+				"@lerna/pulse-till-done": "3.13.0",
+				"@lerna/run-lifecycle": "3.13.0",
+				"@lerna/run-parallel-batches": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"@lerna/version": "3.13.1",
 				"figgy-pudding": "^3.5.1",
 				"fs-extra": "^7.0.0",
-				"libnpm": "^2.0.1",
+				"libnpmaccess": "^3.0.1",
+				"npm-package-arg": "^6.1.0",
+				"npm-registry-fetch": "^3.9.0",
+				"npmlog": "^4.1.2",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
 				"p-pipe": "^1.2.0",
 				"p-reduce": "^1.0.0",
+				"pacote": "^9.5.0",
 				"semver": "^5.5.0"
 			}
 		},
 		"@lerna/pulse-till-done": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.7.1.tgz",
-			"integrity": "sha512-MzpesZeW3Mc+CiAq4zUt9qTXI9uEBBKrubYHE36voQTSkHvu/Rox6YOvfUr+U7P6k8frFPeCgGpfMDTLhiqe6w==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz",
+			"integrity": "sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==",
 			"dev": true,
 			"requires": {
-				"libnpm": "^2.0.1"
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/resolve-symlink": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.6.0.tgz",
-			"integrity": "sha512-TVOAEqHJSQVhNDMFCwEUZPaOETqHDQV1TQWQfC8ZlOqyaUQ7veZUbg0yfG7RPNzlSpvF0ZaGFeR0YhYDAW03GA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz",
+			"integrity": "sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==",
 			"dev": true,
 			"requires": {
 				"fs-extra": "^7.0.0",
-				"libnpm": "^2.0.1",
+				"npmlog": "^4.1.2",
 				"read-cmd-shim": "^1.0.1"
 			}
 		},
 		"@lerna/rimraf-dir": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.10.0.tgz",
-			"integrity": "sha512-RSKSfxPURc58ERCD/PuzorR86lWEvIWNclXYGvIYM76yNGrWiDF44pGHQvB4J+Lxa5M+52ZtZC/eOC7A7YCH4g==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.0.tgz",
+			"integrity": "sha512-kte+pMemulre8cmPqljxIYjCmdLByz8DgHBHXB49kz2EiPf8JJ+hJFt0PzEubEyJZ2YE2EVAx5Tv5+NfGNUQyQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/child-process": "3.3.0",
-				"libnpm": "^2.0.1",
+				"@lerna/child-process": "3.13.0",
+				"npmlog": "^4.1.2",
 				"path-exists": "^3.0.0",
 				"rimraf": "^2.6.2"
 			}
 		},
 		"@lerna/run": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.10.6.tgz",
-			"integrity": "sha512-KS2lWbu/8WUUscQPi9U8sPO6yYpzf/0GmODjpruR1nRi1u/tuncdjTiG+hjGAeFC1BD7YktT9Za6imIpE8RXmA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.13.1.tgz",
+			"integrity": "sha512-nv1oj7bsqppWm1M4ifN+/IIbVu9F4RixrbQD2okqDGYne4RQPAXyb5cEZuAzY/wyGTWWiVaZ1zpj5ogPWvH0bw==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "3.10.6",
-				"@lerna/command": "3.10.6",
-				"@lerna/filter-options": "3.10.6",
-				"@lerna/npm-run-script": "3.10.0",
-				"@lerna/output": "3.6.0",
-				"@lerna/run-parallel-batches": "3.0.0",
-				"@lerna/timer": "3.5.0",
-				"@lerna/validation-error": "3.6.0",
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/npm-run-script": "3.13.0",
+				"@lerna/output": "3.13.0",
+				"@lerna/run-parallel-batches": "3.13.0",
+				"@lerna/timer": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
 				"p-map": "^1.2.0"
 			}
 		},
 		"@lerna/run-lifecycle": {
-			"version": "3.10.5",
-			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.10.5.tgz",
-			"integrity": "sha512-YPmXviaxVlhcKM6IkDTIpTq24mxOuMCilo+MTr1RLoafgB9ZTmP2AHRiFt/sy14wOsq2Zqr0wJyj8KFlDYLTkA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.13.0.tgz",
+			"integrity": "sha512-oyiaL1biZdjpmjh6X/5C4w07wNFyiwXSSHH5GQB4Ay4BPwgq9oNhCcxRoi0UVZlZ1YwzSW8sTwLgj8emkIo3Yg==",
 			"dev": true,
 			"requires": {
-				"@lerna/npm-conf": "3.7.0",
+				"@lerna/npm-conf": "3.13.0",
 				"figgy-pudding": "^3.5.1",
-				"libnpm": "^2.0.1"
+				"npm-lifecycle": "^2.1.0",
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/run-parallel-batches": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0.tgz",
-			"integrity": "sha512-Mj1ravlXF7AkkewKd9YFq9BtVrsStNrvVLedD/b2wIVbNqcxp8lS68vehXVOzoL/VWNEDotvqCQtyDBilCodGw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz",
+			"integrity": "sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==",
 			"dev": true,
 			"requires": {
 				"p-map": "^1.2.0",
@@ -1990,26 +2030,26 @@
 			}
 		},
 		"@lerna/symlink-binary": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.10.0.tgz",
-			"integrity": "sha512-6mQsG+iVjBo8cD8s24O+YgFrwDyUGfUQbK4ryalAXFHI817Zd4xlI3tjg3W99whCt6rt6D0s1fpf8eslMN6dSw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.13.0.tgz",
+			"integrity": "sha512-obc4Y6jxywkdaCe+DB0uTxYqP0IQ8mFWvN+k/YMbwH4G2h7M7lCBWgPy8e7xw/50+1II9tT2sxgx+jMus1sTJg==",
 			"dev": true,
 			"requires": {
-				"@lerna/create-symlink": "3.6.0",
-				"@lerna/package": "3.7.2",
+				"@lerna/create-symlink": "3.13.0",
+				"@lerna/package": "3.13.0",
 				"fs-extra": "^7.0.0",
 				"p-map": "^1.2.0"
 			}
 		},
 		"@lerna/symlink-dependencies": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.10.0.tgz",
-			"integrity": "sha512-vGpg5ydwGgQCuWNX5y7CRL38mGpuLhf1GRq9wMm7IGwnctEsdSNqvvE+LDgqtwEZASu5+vffYUkL0VlFXl8uWA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.13.0.tgz",
+			"integrity": "sha512-7CyN5WYEPkbPLbqHBIQg/YiimBzb5cIGQB0E9IkLs3+racq2vmUNQZn38LOaazQacAA83seB+zWSxlI6H+eXSg==",
 			"dev": true,
 			"requires": {
-				"@lerna/create-symlink": "3.6.0",
-				"@lerna/resolve-symlink": "3.6.0",
-				"@lerna/symlink-binary": "3.10.0",
+				"@lerna/create-symlink": "3.13.0",
+				"@lerna/resolve-symlink": "3.13.0",
+				"@lerna/symlink-binary": "3.13.0",
 				"fs-extra": "^7.0.0",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
@@ -2017,40 +2057,41 @@
 			}
 		},
 		"@lerna/timer": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.5.0.tgz",
-			"integrity": "sha512-TAb99hqQN6E3JBGtG9iyZNPq1/DbmqgBOeNrKtdJsGvIeX/NGLgUDWMrj2h04V4O+jpBFmSf6HIld6triKmxCA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz",
+			"integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==",
 			"dev": true
 		},
 		"@lerna/validation-error": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.6.0.tgz",
-			"integrity": "sha512-MWltncGO5VgMS0QedTlZCjFUMF/evRjDMMHrtVorkIB2Cp5xy0rkKa8iDBG43qpUWeG1giwi58yUlETBcWfILw==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz",
+			"integrity": "sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==",
 			"dev": true,
 			"requires": {
-				"libnpm": "^2.0.1"
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/version": {
-			"version": "3.10.6",
-			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.10.6.tgz",
-			"integrity": "sha512-77peW2ROlHHl1e/tHBUmhpb8tsO6CIdlx34XapZhUuIVykrkOuqVFFxqMecrGG8SJe0e3l1G+Fah7bJTQcG0kw==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.13.1.tgz",
+			"integrity": "sha512-WpfKc5jZBBOJ6bFS4atPJEbHSiywQ/Gcd+vrwaEGyQHWHQZnPTvhqLuq3q9fIb9sbuhH5pSY6eehhuBrKqTnjg==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "3.10.6",
-				"@lerna/check-working-tree": "3.10.0",
-				"@lerna/child-process": "3.3.0",
-				"@lerna/collect-updates": "3.10.1",
-				"@lerna/command": "3.10.6",
-				"@lerna/conventional-commits": "3.10.0",
-				"@lerna/output": "3.6.0",
-				"@lerna/prompt": "3.6.0",
-				"@lerna/run-lifecycle": "3.10.5",
-				"@lerna/validation-error": "3.6.0",
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/check-working-tree": "3.13.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/collect-updates": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/conventional-commits": "3.13.0",
+				"@lerna/github-client": "3.13.1",
+				"@lerna/output": "3.13.0",
+				"@lerna/prompt": "3.13.0",
+				"@lerna/run-lifecycle": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
 				"chalk": "^2.3.1",
 				"dedent": "^0.7.0",
-				"libnpm": "^2.0.1",
 				"minimatch": "^3.0.4",
+				"npmlog": "^4.1.2",
 				"p-map": "^1.2.0",
 				"p-pipe": "^1.2.0",
 				"p-reduce": "^1.0.0",
@@ -2069,12 +2110,12 @@
 			}
 		},
 		"@lerna/write-log-file": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.6.0.tgz",
-			"integrity": "sha512-OkLK99V6sYXsJsYg+O9wtiFS3z6eUPaiz2e6cXJt80mfIIdI1t2dnmyua0Ib5cZWExQvx2z6Y32Wlf0MnsoNsA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz",
+			"integrity": "sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==",
 			"dev": true,
 			"requires": {
-				"libnpm": "^2.0.1",
+				"npmlog": "^4.1.2",
 				"write-file-atomic": "^2.3.0"
 			}
 		},
@@ -2094,38 +2135,51 @@
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
 		},
-		"@octokit/rest": {
-			"version": "15.18.1",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.18.1.tgz",
-			"integrity": "sha512-g2tecjp2TEtYV8bKAFvfQtu+W29HM7ektmWmw8zrMy9/XCKDEYRErR2YvvhN9+IxkLC4O3lDqYP4b6WgsL6Utw==",
+		"@octokit/endpoint": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
+			"integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
 			"dev": true,
 			"requires": {
-				"before-after-hook": "^1.1.0",
+				"deepmerge": "3.2.0",
+				"is-plain-object": "^2.0.4",
+				"universal-user-agent": "^2.0.1",
+				"url-template": "^2.0.8"
+			}
+		},
+		"@octokit/plugin-enterprise-rest": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.1.2.tgz",
+			"integrity": "sha512-EWKrEqhSgzqWXI9DuEsEI691PNJppm/a4zW62//te27I8pYI5zSNVR3wtNUk0NWPlvs7054YzGZochwbUbhI8A==",
+			"dev": true
+		},
+		"@octokit/request": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.3.0.tgz",
+			"integrity": "sha512-5YRqYNZOAaL7+nt7w3Scp6Sz4P2g7wKFP9npx1xdExMomk8/M/ICXVLYVam2wzxeY0cIc6wcKpjC5KI4jiNbGw==",
+			"dev": true,
+			"requires": {
+				"@octokit/endpoint": "^3.1.1",
+				"is-plain-object": "^2.0.4",
+				"node-fetch": "^2.3.0",
+				"universal-user-agent": "^2.0.1"
+			}
+		},
+		"@octokit/rest": {
+			"version": "16.16.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.16.2.tgz",
+			"integrity": "sha512-sNOIcYEzEQD9ovDyOnDmFyZZvU+3ytgrBG/BtCSxJ0e9/j9BKIGH/zyG6py/5DzImcj/U/PA77OqcBrPH3vaQg==",
+			"dev": true,
+			"requires": {
+				"@octokit/request": "2.3.0",
+				"before-after-hook": "^1.2.0",
 				"btoa-lite": "^1.0.0",
-				"debug": "^3.1.0",
-				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^2.2.0",
-				"lodash": "^4.17.4",
-				"node-fetch": "^2.1.1",
+				"lodash.get": "^4.4.2",
+				"lodash.set": "^4.3.2",
+				"lodash.uniq": "^4.5.0",
+				"octokit-pagination-methods": "^1.1.0",
 				"universal-user-agent": "^2.0.0",
 				"url-template": "^2.0.8"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				}
 			}
 		},
 		"@svgr/cli": {
@@ -2166,9 +2220,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.20",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.20.tgz",
-			"integrity": "sha512-9spv6SklidqxevvZyOUGjZVz4QRXGu2dNaLyXIFzFYZW0AGDykzPRIUFJXTlQXyfzAucddwTcGtJNim8zqSOPA==",
+			"version": "11.9.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
+			"integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
 			"dev": true
 		},
 		"@types/q": {
@@ -2178,175 +2232,179 @@
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
-			"integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.3.tgz",
+			"integrity": "sha512-xy3m06+Iu4D32+6soz6zLnwznigXJRuFNTovBX2M4GqVqLb0dnyWLbPnpcXvUSdEN+9DVyDeaq2jyH1eIL2LZQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/helper-module-context": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/wast-parser": "1.7.11"
+				"@webassemblyjs/helper-module-context": "1.8.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.3",
+				"@webassemblyjs/wast-parser": "1.8.3"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
-			"integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.3.tgz",
+			"integrity": "sha512-vq1TISG4sts4f0lDwMUM0f3kpe0on+G3YyV5P0IySHFeaLKRYZ++n2fCFfG4TcCMYkqFeTUYFxm75L3ddlk2xA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
-			"integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.3.tgz",
+			"integrity": "sha512-BmWEynI4FnZbjk8CaYZXwcv9a6gIiu+rllRRouQUo73hglanXD3AGFJE7Q4JZCoVE0p5/jeX6kf5eKa3D4JxwQ==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
-			"integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.3.tgz",
+			"integrity": "sha512-iVIMhWnNHoFB94+/2l7LpswfCsXeMRnWfExKtqsZ/E2NxZyUx9nTeKK/MEMKTQNEpyfznIUX06OchBHQ+VKi/Q==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-code-frame": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
-			"integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.3.tgz",
+			"integrity": "sha512-K1UxoJML7GKr1QXR+BG7eXqQkvu+eEeTjlSl5wUFQ6W6vaOc5OwSxTcb3oE9x/3+w4NHhrIKD4JXXCZmLdL2cg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/wast-printer": "1.7.11"
+				"@webassemblyjs/wast-printer": "1.8.3"
 			}
 		},
 		"@webassemblyjs/helper-fsm": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
-			"integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.3.tgz",
+			"integrity": "sha512-387zipfrGyO77/qm7/SDUiZBjQ5KGk4qkrVIyuoubmRNIiqn3g+6ijY8BhnlGqsCCQX5bYKOnttJobT5xoyviA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-module-context": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
-			"integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==",
-			"dev": true
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.3.tgz",
+			"integrity": "sha512-lPLFdQfaRssfnGEJit5Sk785kbBPPPK4ZS6rR5W/8hlUO/5v3F+rN8XuUcMj/Ny9iZiyKhhuinWGTUuYL4VKeQ==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/ast": "1.8.3",
+				"mamacro": "^0.0.3"
+			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
-			"integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.3.tgz",
+			"integrity": "sha512-R1nJW7bjyJLjsJQR5t3K/9LJ0QWuZezl8fGa49DZq4IVaejgvkbNlKEQxLYTC579zgT4IIIVHb5JA59uBPHXyw==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
-			"integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.3.tgz",
+			"integrity": "sha512-P6F7D61SJY73Yz+fs49Q3+OzlYAZP86OfSpaSY448KzUy65NdfzDmo2NPVte+Rw4562MxEAacvq/mnDuvRWOcg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11"
+				"@webassemblyjs/ast": "1.8.3",
+				"@webassemblyjs/helper-buffer": "1.8.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.3",
+				"@webassemblyjs/wasm-gen": "1.8.3"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
-			"integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.3.tgz",
+			"integrity": "sha512-UD4HuLU99hjIvWz1pD68b52qsepWQlYCxDYVFJQfHh3BHyeAyAlBJ+QzLR1nnS5J6hAzjki3I3AoJeobNNSZlg==",
 			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
-			"integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.3.tgz",
+			"integrity": "sha512-XXd3s1BmkC1gpGABuCRLqCGOD6D2L+Ma2BpwpjrQEHeQATKWAQtxAyU9Z14/z8Ryx6IG+L4/NDkIGHrccEhRUg==",
 			"dev": true,
 			"requires": {
-				"@xtuc/long": "4.2.1"
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
-			"integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.3.tgz",
+			"integrity": "sha512-Wv/WH9Zo5h5ZMyfCNpUrjFsLZ3X1amdfEuwdb7MLdG3cPAjRS6yc6ElULlpjLiiBTuzvmLhr3ENsuGyJ3wyCgg==",
 			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
-			"integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.3.tgz",
+			"integrity": "sha512-nB19eUx3Yhi1Vvv3yev5r+bqQixZprMtaoCs1brg9Efyl8Hto3tGaUoZ0Yb4Umn/gQCyoEGFfUxPLp1/8+Jvnw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/helper-wasm-section": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11",
-				"@webassemblyjs/wasm-opt": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11",
-				"@webassemblyjs/wast-printer": "1.7.11"
+				"@webassemblyjs/ast": "1.8.3",
+				"@webassemblyjs/helper-buffer": "1.8.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.3",
+				"@webassemblyjs/helper-wasm-section": "1.8.3",
+				"@webassemblyjs/wasm-gen": "1.8.3",
+				"@webassemblyjs/wasm-opt": "1.8.3",
+				"@webassemblyjs/wasm-parser": "1.8.3",
+				"@webassemblyjs/wast-printer": "1.8.3"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
-			"integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.3.tgz",
+			"integrity": "sha512-sDNmu2nLBJZ/huSzlJvd9IK8B1EjCsOl7VeMV9VJPmxKYgTJ47lbkSP+KAXMgZWGcArxmcrznqm7FrAPQ7vVGg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/ieee754": "1.7.11",
-				"@webassemblyjs/leb128": "1.7.11",
-				"@webassemblyjs/utf8": "1.7.11"
+				"@webassemblyjs/ast": "1.8.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.3",
+				"@webassemblyjs/ieee754": "1.8.3",
+				"@webassemblyjs/leb128": "1.8.3",
+				"@webassemblyjs/utf8": "1.8.3"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
-			"integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.3.tgz",
+			"integrity": "sha512-j8lmQVFR+FR4/645VNgV4R/Jz8i50eaPAj93GZyd3EIJondVshE/D9pivpSDIXyaZt+IkCodlzOoZUE4LnQbeA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11"
+				"@webassemblyjs/ast": "1.8.3",
+				"@webassemblyjs/helper-buffer": "1.8.3",
+				"@webassemblyjs/wasm-gen": "1.8.3",
+				"@webassemblyjs/wasm-parser": "1.8.3"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
-			"integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.3.tgz",
+			"integrity": "sha512-NBI3SNNtRoy4T/KBsRZCAWUzE9lI94RH2nneLwa1KKIrt/2zzcTavWg6oY05ArCbb/PZDk3OUi63CD1RYtN65w==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-api-error": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/ieee754": "1.7.11",
-				"@webassemblyjs/leb128": "1.7.11",
-				"@webassemblyjs/utf8": "1.7.11"
+				"@webassemblyjs/ast": "1.8.3",
+				"@webassemblyjs/helper-api-error": "1.8.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.3",
+				"@webassemblyjs/ieee754": "1.8.3",
+				"@webassemblyjs/leb128": "1.8.3",
+				"@webassemblyjs/utf8": "1.8.3"
 			}
 		},
 		"@webassemblyjs/wast-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
-			"integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.3.tgz",
+			"integrity": "sha512-gZPst4CNcmGtKC1eYQmgCx6gwQvxk4h/nPjfPBbRoD+Raw3Hs+BS3yhrfgyRKtlYP+BJ8LcY9iFODEQofl2qbg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/floating-point-hex-parser": "1.7.11",
-				"@webassemblyjs/helper-api-error": "1.7.11",
-				"@webassemblyjs/helper-code-frame": "1.7.11",
-				"@webassemblyjs/helper-fsm": "1.7.11",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.8.3",
+				"@webassemblyjs/floating-point-hex-parser": "1.8.3",
+				"@webassemblyjs/helper-api-error": "1.8.3",
+				"@webassemblyjs/helper-code-frame": "1.8.3",
+				"@webassemblyjs/helper-fsm": "1.8.3",
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
-			"integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.3.tgz",
+			"integrity": "sha512-DTA6kpXuHK4PHu16yAD9QVuT1WZQRT7079oIFFmFSjqjLWGXS909I/7kiLTn931mcj7wGsaUNungjwNQ2lGQ3Q==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/wast-parser": "1.7.11",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.8.3",
+				"@webassemblyjs/wast-parser": "1.8.3",
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@xtuc/ieee754": {
@@ -2356,9 +2414,9 @@
 			"dev": true
 		},
 		"@xtuc/long": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
 		"JSONStream": {
@@ -2411,9 +2469,9 @@
 			}
 		},
 		"acorn": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.6.tgz",
-			"integrity": "sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+			"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
 			"dev": true
 		},
 		"acorn-dynamic-import": {
@@ -2474,9 +2532,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-			"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+			"version": "6.9.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+			"integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
@@ -2550,6 +2608,17 @@
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				}
 			}
 		},
 		"aproba": {
@@ -2753,12 +2822,12 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"async-each": {
@@ -3355,23 +3424,10 @@
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
 		},
-		"bin-links": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.2.tgz",
-			"integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
-			"dev": true,
-			"requires": {
-				"bluebird": "^3.5.0",
-				"cmd-shim": "^2.0.2",
-				"gentle-fs": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"write-file-atomic": "^2.3.0"
-			}
-		},
 		"binary-extensions": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
+			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
 			"dev": true
 		},
 		"bl": {
@@ -3630,14 +3686,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
-			"integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.2.tgz",
+			"integrity": "sha512-ISS/AIAiHERJ3d45Fz0AVYKkgcy+F/eJHzKEvv1j0wwKGKD9T3BrwKr/5g45L+Y4XIK5PlTqefHciRFcfE1Jxg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000929",
-				"electron-to-chromium": "^1.3.103",
-				"node-releases": "^1.1.3"
+				"caniuse-lite": "^1.0.30000939",
+				"electron-to-chromium": "^1.3.113",
+				"node-releases": "^1.1.8"
 			}
 		},
 		"btoa-lite": {
@@ -3682,9 +3738,9 @@
 			"dev": true
 		},
 		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+			"integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
 			"dev": true
 		},
 		"builtin-status-codes": {
@@ -3845,15 +3901,15 @@
 			}
 		},
 		"caniuse-db": {
-			"version": "1.0.30000933",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000933.tgz",
-			"integrity": "sha512-DdIlPHIGtjUS2sH/yioeS9CS0JsWk8zGqid0OdfYhwJvufYZKZPcgerEX9E7PWOnshDc9IndnEJDoqauv+JUHA==",
+			"version": "1.0.30000939",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000939.tgz",
+			"integrity": "sha512-nB5tLf3hOs+biXl1lhKjHRgNC0J1I7H52h/t1FP7qxARKKwpB0z+P/JewJLYAlxCBP/q7rxJzQzHHrQMl0viKg==",
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000933",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000933.tgz",
-			"integrity": "sha512-d3QXv7eFTU40DSedSP81dV/ajcGSKpT+GW+uhtWmLvQm9bPk0KK++7i1e2NSW/CXGZhWFt2mFbFtCJ5I5bMuVA==",
+			"version": "1.0.30000939",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz",
+			"integrity": "sha512-oXB23ImDJOgQpGjRv1tCtzAvJr4/OvrHi5SO2vUgB0g0xpdZZoA/BxfImiWfdwoYdUTtQrPsXsvYU/dmCSM8gg==",
 			"dev": true
 		},
 		"caseless": {
@@ -3886,24 +3942,23 @@
 			"dev": true
 		},
 		"chokidar": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
+			"integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
-				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.2.2",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
 				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.1",
+				"inherits": "^2.0.3",
 				"is-binary-path": "^1.0.0",
 				"is-glob": "^4.0.0",
-				"lodash.debounce": "^4.0.8",
-				"normalize-path": "^2.1.1",
+				"normalize-path": "^3.0.0",
 				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.5"
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.0"
 			}
 		},
 		"chownr": {
@@ -4231,12 +4286,12 @@
 			"dev": true
 		},
 		"compressible": {
-			"version": "2.0.15",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
-			"integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
+			"integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
 			"dev": true,
 			"requires": {
-				"mime-db": ">= 1.36.0 < 2"
+				"mime-db": ">= 1.38.0 < 2"
 			}
 		},
 		"compression": {
@@ -4274,8 +4329,8 @@
 		},
 		"concat-with-sourcemaps": {
 			"version": "1.1.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
-			"integrity": "sha1-1OqT8FriV5CVG5nns7CeOQikCC4=",
+			"resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+			"integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
 			"dev": true,
 			"requires": {
 				"source-map": "^0.6.1"
@@ -4283,8 +4338,8 @@
 			"dependencies": {
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
 			}
@@ -4339,9 +4394,9 @@
 			"dev": true
 		},
 		"conventional-changelog-angular": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.2.tgz",
-			"integrity": "sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+			"integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
@@ -4349,12 +4404,12 @@
 			}
 		},
 		"conventional-changelog-core": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.5.tgz",
-			"integrity": "sha512-iwqAotS4zk0wA4S84YY1JCUG7X3LxaRjJxuUo6GI4dZuIy243j5nOg/Ora35ExT4DOiw5dQbMMQvw2SUjh6moQ==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz",
+			"integrity": "sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-writer": "^4.0.2",
+				"conventional-changelog-writer": "^4.0.3",
 				"conventional-commits-parser": "^3.0.1",
 				"dateformat": "^3.0.0",
 				"get-pkg-repo": "^1.0.0",
@@ -4432,15 +4487,15 @@
 			"dev": true
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.2.tgz",
-			"integrity": "sha512-d8/FQY/fix2xXEBUhOo8u3DCbyEw3UOQgYHxLsPDw+wHUDma/GQGAGsGtoH876WyNs32fViHmTOUrgRKVLvBug==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz",
+			"integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^2.0.1",
 				"dateformat": "^3.0.0",
-				"handlebars": "^4.0.2",
+				"handlebars": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.2.1",
 				"meow": "^4.0.0",
@@ -4570,9 +4625,9 @@
 			}
 		},
 		"core-js": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
-			"integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -4582,14 +4637,15 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
-			"integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
+			"integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
 			"dev": true,
 			"requires": {
 				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
 				"js-yaml": "^3.9.0",
+				"lodash.get": "^4.4.2",
 				"parse-json": "^4.0.0"
 			}
 		},
@@ -4737,8 +4793,8 @@
 		},
 		"css-declaration-sorter": {
 			"version": "4.0.1",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
-			"integrity": "sha1-wZiUD2OnbX42wecQGLABchBUyyI=",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+			"integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.1",
@@ -4747,8 +4803,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -4758,14 +4814,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -4797,7 +4853,7 @@
 		},
 		"css-modules-loader-core": {
 			"version": "1.1.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
 			"integrity": "sha1-WQhmgpShvs0mGuCkziGwtVHyHRY=",
 			"dev": true,
 			"requires": {
@@ -4811,13 +4867,13 @@
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -4830,7 +4886,7 @@
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
-							"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-2.0.0.tgz",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 							"dev": true
 						}
@@ -4838,13 +4894,13 @@
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/has-flag/-/has-flag-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
 					"dev": true
 				},
 				"postcss": {
 					"version": "6.0.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-6.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
 					"integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
 					"dev": true,
 					"requires": {
@@ -4855,7 +4911,7 @@
 				},
 				"postcss-modules-extract-imports": {
 					"version": "1.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
 					"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
 					"dev": true,
 					"requires": {
@@ -4864,7 +4920,7 @@
 				},
 				"supports-color": {
 					"version": "3.2.3",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-3.2.3.tgz",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
@@ -4948,7 +5004,7 @@
 		},
 		"css-unit-converter": {
 			"version": "1.1.1",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
 			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
 			"dev": true
 		},
@@ -4959,9 +5015,9 @@
 			"dev": true
 		},
 		"css-what": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
-			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
 			"dev": true
 		},
 		"cssesc": {
@@ -5012,8 +5068,8 @@
 		},
 		"cssnano-preset-default": {
 			"version": "4.0.7",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
-			"integrity": "sha1-UexmLM/KD4izltzZZ5zbkxvhf3Y=",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+			"integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
 			"dev": true,
 			"requires": {
 				"css-declaration-sorter": "^4.0.1",
@@ -5050,8 +5106,8 @@
 			"dependencies": {
 				"caniuse-api": {
 					"version": "3.0.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/caniuse-api/-/caniuse-api-3.0.0.tgz",
-					"integrity": "sha1-Xk2Q4idJYdRikZl99Znj7QCO5MA=",
+					"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+					"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
 					"dev": true,
 					"requires": {
 						"browserslist": "^4.0.0",
@@ -5062,8 +5118,8 @@
 				},
 				"color": {
 					"version": "3.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/color/-/color-3.1.0.tgz",
-					"integrity": "sha1-2On7CWcyh1d0yEv5IoFd8DCND/w=",
+					"resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
+					"integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.1",
@@ -5072,8 +5128,8 @@
 				},
 				"color-string": {
 					"version": "1.5.3",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/color-string/-/color-string-1.5.3.tgz",
-					"integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+					"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
 					"dev": true,
 					"requires": {
 						"color-name": "^1.0.0",
@@ -5082,14 +5138,14 @@
 				},
 				"cssesc": {
 					"version": "2.0.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cssesc/-/cssesc-2.0.0.tgz",
-					"integrity": "sha1-OxO9G7HLNuG8taTc0n9UxdyzVwM=",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
 					"dev": true
 				},
 				"is-svg": {
 					"version": "3.0.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-svg/-/is-svg-3.0.0.tgz",
-					"integrity": "sha1-kyHb0pwhLlypnE+peUxxS8r6L3U=",
+					"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+					"integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
 					"dev": true,
 					"requires": {
 						"html-comment-regex": "^1.1.0"
@@ -5097,14 +5153,14 @@
 				},
 				"normalize-url": {
 					"version": "3.3.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk=",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
 					"dev": true
 				},
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -5114,8 +5170,8 @@
 				},
 				"postcss-calc": {
 					"version": "7.0.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-calc/-/postcss-calc-7.0.1.tgz",
-					"integrity": "sha1-Ntd7qwI7Dsu5eJ2E3LI8SUEUVDY=",
+					"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+					"integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
 					"dev": true,
 					"requires": {
 						"css-unit-converter": "^1.1.1",
@@ -5126,8 +5182,8 @@
 				},
 				"postcss-colormin": {
 					"version": "4.0.3",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
-					"integrity": "sha1-rgYLzpPteUrHEmTwgTLVUJVr04E=",
+					"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+					"integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
 					"dev": true,
 					"requires": {
 						"browserslist": "^4.0.0",
@@ -5139,8 +5195,8 @@
 				},
 				"postcss-convert-values": {
 					"version": "4.0.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
-					"integrity": "sha1-yjgT7U2g+BL51DcDWE5Enr4Ymn8=",
+					"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+					"integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
 					"dev": true,
 					"requires": {
 						"postcss": "^7.0.0",
@@ -5149,8 +5205,8 @@
 				},
 				"postcss-discard-comments": {
 					"version": "4.0.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
-					"integrity": "sha1-H7q9LCRr/2qq15l7KwkY9NevQDM=",
+					"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+					"integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
 					"dev": true,
 					"requires": {
 						"postcss": "^7.0.0"
@@ -5158,8 +5214,8 @@
 				},
 				"postcss-discard-duplicates": {
 					"version": "4.0.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
-					"integrity": "sha1-P+EzzTyCKC5VD8myORdqkge3hOs=",
+					"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+					"integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
 					"dev": true,
 					"requires": {
 						"postcss": "^7.0.0"
@@ -5167,8 +5223,8 @@
 				},
 				"postcss-discard-empty": {
 					"version": "4.0.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
-					"integrity": "sha1-yMlR6fc+2UKAGUWERKAq2Qu592U=",
+					"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+					"integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
 					"dev": true,
 					"requires": {
 						"postcss": "^7.0.0"
@@ -5176,8 +5232,8 @@
 				},
 				"postcss-discard-overridden": {
 					"version": "4.0.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
-					"integrity": "sha1-ZSrvipZybwKfXj4AFG7npOdV/1c=",
+					"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+					"integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
 					"dev": true,
 					"requires": {
 						"postcss": "^7.0.0"
@@ -5185,8 +5241,8 @@
 				},
 				"postcss-merge-longhand": {
 					"version": "4.0.11",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
-					"integrity": "sha1-YvSaE+Sg7gTnuY9CuxYGLKJUniQ=",
+					"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+					"integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
 					"dev": true,
 					"requires": {
 						"css-color-names": "0.0.4",
@@ -5197,8 +5253,8 @@
 				},
 				"postcss-merge-rules": {
 					"version": "4.0.3",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
-					"integrity": "sha1-NivqT/Wh+Y5AdacTxsslrv75plA=",
+					"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+					"integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
 					"dev": true,
 					"requires": {
 						"browserslist": "^4.0.0",
@@ -5211,7 +5267,7 @@
 					"dependencies": {
 						"postcss-selector-parser": {
 							"version": "3.1.1",
-							"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+							"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
 							"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
 							"dev": true,
 							"requires": {
@@ -5224,8 +5280,8 @@
 				},
 				"postcss-minify-font-values": {
 					"version": "4.0.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
-					"integrity": "sha1-zUw0TM5HQ0P6xdgiBqssvLiv1aY=",
+					"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+					"integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
 					"dev": true,
 					"requires": {
 						"postcss": "^7.0.0",
@@ -5234,8 +5290,8 @@
 				},
 				"postcss-minify-gradients": {
 					"version": "4.0.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
-					"integrity": "sha1-k7KcL/UJnFNe7NpWxKpuZlpmNHE=",
+					"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+					"integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
 					"dev": true,
 					"requires": {
 						"cssnano-util-get-arguments": "^4.0.0",
@@ -5246,8 +5302,8 @@
 				},
 				"postcss-minify-params": {
 					"version": "4.0.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
-					"integrity": "sha1-a5zvAwwR41Jh+V9hjJADbWgNuHQ=",
+					"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+					"integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
 					"dev": true,
 					"requires": {
 						"alphanum-sort": "^1.0.0",
@@ -5260,8 +5316,8 @@
 				},
 				"postcss-minify-selectors": {
 					"version": "4.0.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
-					"integrity": "sha1-4uXrQL/uUA0M2SQ1APX46kJi+9g=",
+					"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+					"integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
 					"dev": true,
 					"requires": {
 						"alphanum-sort": "^1.0.0",
@@ -5272,7 +5328,7 @@
 					"dependencies": {
 						"postcss-selector-parser": {
 							"version": "3.1.1",
-							"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+							"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
 							"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
 							"dev": true,
 							"requires": {
@@ -5285,8 +5341,8 @@
 				},
 				"postcss-normalize-charset": {
 					"version": "4.0.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
-					"integrity": "sha1-izWt067oOhNrBHHg1ZvlilAoXdQ=",
+					"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+					"integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
 					"dev": true,
 					"requires": {
 						"postcss": "^7.0.0"
@@ -5294,8 +5350,8 @@
 				},
 				"postcss-normalize-url": {
 					"version": "4.0.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
-					"integrity": "sha1-EOQ3+GvHx+WPe5ZS7YeNqqlfquE=",
+					"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+					"integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
 					"dev": true,
 					"requires": {
 						"is-absolute-url": "^2.0.0",
@@ -5306,8 +5362,8 @@
 				},
 				"postcss-ordered-values": {
 					"version": "4.1.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
-					"integrity": "sha1-DPdcgg7H1cTSgBiVWeC1ceusDu4=",
+					"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+					"integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
 					"dev": true,
 					"requires": {
 						"cssnano-util-get-arguments": "^4.0.0",
@@ -5317,8 +5373,8 @@
 				},
 				"postcss-reduce-initial": {
 					"version": "4.0.3",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
-					"integrity": "sha1-f9QuvqXpyBRgljniwuhK4nC6SN8=",
+					"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+					"integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
 					"dev": true,
 					"requires": {
 						"browserslist": "^4.0.0",
@@ -5329,8 +5385,8 @@
 				},
 				"postcss-reduce-transforms": {
 					"version": "4.0.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
-					"integrity": "sha1-F++kBerMbge+NBSlyi0QdGgdTik=",
+					"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+					"integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
 					"dev": true,
 					"requires": {
 						"cssnano-util-get-match": "^4.0.0",
@@ -5341,8 +5397,8 @@
 				},
 				"postcss-selector-parser": {
 					"version": "5.0.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-					"integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"dev": true,
 					"requires": {
 						"cssesc": "^2.0.0",
@@ -5352,8 +5408,8 @@
 				},
 				"postcss-svgo": {
 					"version": "4.0.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
-					"integrity": "sha1-F7mXvHEbMzurFDqu07jT1uPTglg=",
+					"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+					"integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
 					"dev": true,
 					"requires": {
 						"is-svg": "^3.0.0",
@@ -5364,8 +5420,8 @@
 				},
 				"postcss-unique-selectors": {
 					"version": "4.0.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
-					"integrity": "sha1-lEaRHzKJv9ZMbWgPBzwDsfnuS6w=",
+					"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+					"integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
 					"dev": true,
 					"requires": {
 						"alphanum-sort": "^1.0.0",
@@ -5375,14 +5431,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -5392,20 +5448,20 @@
 		},
 		"cssnano-util-get-arguments": {
 			"version": "4.0.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
 			"integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
 			"dev": true
 		},
 		"cssnano-util-get-match": {
 			"version": "4.0.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
 			"integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
 			"dev": true
 		},
 		"cssnano-util-raw-cache": {
 			"version": "4.0.1",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
-			"integrity": "sha1-sm1f1fcqEd/np4RvtMZyYPlr8oI=",
+			"resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+			"integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
@@ -5413,8 +5469,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -5424,14 +5480,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -5441,8 +5497,8 @@
 		},
 		"cssnano-util-same-parent": {
 			"version": "4.0.1",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
-			"integrity": "sha1-V0CC+yhZ0ttDOFWDXZqEVuoYu/M=",
+			"resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+			"integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
 			"dev": true
 		},
 		"csso": {
@@ -5467,15 +5523,15 @@
 			}
 		},
 		"cssom": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
-			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+			"integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -5624,50 +5680,20 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
 		},
+		"deepmerge": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+			"integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
+			"dev": true
+		},
 		"default-gateway": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
-			"integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.1.2.tgz",
+			"integrity": "sha512-xhJUAp3u02JsBGovj0V6B6uYhKCUOmiNc8xGmReUwGu77NmvcpxPVB0pCielxMFumO7CmXBG02XjM8HB97k8Hw==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.10.0",
+				"execa": "^1.0.0",
 				"ip-regex": "^2.1.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				}
 			}
 		},
 		"defaults": {
@@ -5924,21 +5950,13 @@
 			}
 		},
 		"dom-serializer": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "~1.1.1",
-				"entities": "~1.1.1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-					"dev": true
-				}
+				"domelementtype": "^1.3.0",
+				"entities": "^1.1.1"
 			}
 		},
 		"domain-browser": {
@@ -5981,6 +5999,12 @@
 				"is-obj": "^1.0.0"
 			}
 		},
+		"dotenv": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+			"dev": true
+		},
 		"du": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/du/-/du-0.1.0.tgz",
@@ -6005,9 +6029,9 @@
 			"dev": true
 		},
 		"duplexify": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
@@ -6039,9 +6063,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.109",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.109.tgz",
-			"integrity": "sha512-1qhgVZD9KIULMyeBkbjU/dWmm30zpPUfdWZfVO3nPhbtqMHJqHr4Ua5wBcWtAymVFrUCuAJxjMF1OhG+bR21Ow==",
+			"version": "1.3.113",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
+			"integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==",
 			"dev": true
 		},
 		"elliptic": {
@@ -6060,9 +6084,9 @@
 			}
 		},
 		"emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
 			"dev": true
 		},
 		"emojis-list": {
@@ -6162,9 +6186,9 @@
 			}
 		},
 		"es6-promise": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-			"integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+			"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
 			"dev": true
 		},
 		"es6-promisify": {
@@ -6189,9 +6213,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -6329,18 +6353,18 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.0.0.tgz",
-			"integrity": "sha512-kWuiJxzV5NwOwZcpyozTzDT5KJhBw292bbYro9Is7BWnbNMg15Gmpluc1CTetiCatF8DRkNvgPAOaSyg+bYr3g==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
+			"integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
 			}
 		},
 		"eslint-config-wix": {
-			"version": "1.1.21",
-			"resolved": "https://registry.npmjs.org/eslint-config-wix/-/eslint-config-wix-1.1.21.tgz",
-			"integrity": "sha512-Nn+W4bB1i4vvAR40Lhqli1ni/wo38dJEgAucsAjJ8NYCkUn9Km4b9i5QzLxBnB9pHMAF4wnbaMxHKcKSqCZVCw==",
+			"version": "1.1.28",
+			"resolved": "https://registry.npmjs.org/eslint-config-wix/-/eslint-config-wix-1.1.28.tgz",
+			"integrity": "sha512-X6NL8C5SbvizkrN+JRt4Mhj2VqJHo0cY9VJvAROstIpPg/koRViDNa3hEUpcz+mfZz8UoPKCk6e3KM4Kq+7/MA==",
 			"dev": true,
 			"requires": {
 				"babel-eslint": "^7.0.0",
@@ -6417,17 +6441,17 @@
 			"dev": true
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.0.tgz",
-			"integrity": "sha512-KpibpIdKT0nbDG7G/ILWoZoN5G9cj3h1IHARxzvHk5Nt2LQ7oPUutbO9QbT1FKNHLPZB6BaoA1ASSLOiJZVEUQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz",
+			"integrity": "sha512-7gSSmwb3A+fQwtw0arguwMdOdzmKUgnUcbSNlo+GjKLAQFuC2EZxWqG9XHRI8VscBJD5a8raz3RuxQNFW+XJbw==",
 			"dev": true,
 			"requires": {
 				"aria-query": "^3.0.0",
 				"array-includes": "^3.0.3",
 				"ast-types-flow": "^0.0.7",
-				"axobject-query": "^2.0.2",
+				"axobject-query": "^2.0.1",
 				"damerau-levenshtein": "^1.0.4",
-				"emoji-regex": "^7.0.2",
+				"emoji-regex": "^6.5.1",
 				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.0.1"
 			},
@@ -6503,13 +6527,13 @@
 			"dev": true
 		},
 		"eslint-plugin-wix-style-react": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-wix-style-react/-/eslint-plugin-wix-style-react-1.0.4.tgz",
-			"integrity": "sha512-soxqmGcotbKE+sQjBwc/8Uf10wWYNPa1B5PzvQ5EGDnSwGgy5aQ3Y8lvzTk364MUMgBHcYSmt5lMrJ5i2WxFSQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-wix-style-react/-/eslint-plugin-wix-style-react-1.0.7.tgz",
+			"integrity": "sha512-ggv310WftMu/Irs/IO6TPKMY2j0GGckTxZ9diFw2cI3514FHYoBJGgmu62piFBz/Q26I3vg6G6KMqp3TPml8ew==",
 			"dev": true,
 			"requires": {
 				"requireindex": "~1.1.0",
-				"resolve": "^1.9.0",
+				"resolve": "^1.10.0",
 				"semver": "^5.6.0"
 			}
 		},
@@ -6578,9 +6602,9 @@
 			"dev": true
 		},
 		"estree-walker": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
-			"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+			"integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
 			"dev": true
 		},
 		"esutils": {
@@ -7053,12 +7077,6 @@
 				"pkg-dir": "^3.0.0"
 			}
 		},
-		"find-npm-prefix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
-			"integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
-			"dev": true
-		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -7110,32 +7128,38 @@
 			"dev": true
 		},
 		"flush-write-stream": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.3.6"
 			}
 		},
 		"follow-redirects": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-			"integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+			"integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
 			"dev": true,
 			"requires": {
-				"debug": "=3.1.0"
+				"debug": "^3.2.6"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
@@ -7233,17 +7257,6 @@
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
 			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
 			"dev": true
-		},
-		"fs-vacuum": {
-			"version": "1.2.10",
-			"resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-			"integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"path-is-inside": "^1.0.1",
-				"rimraf": "^2.5.2"
-			}
 		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
@@ -7919,7 +7932,7 @@
 		},
 		"generic-names": {
 			"version": "1.0.3",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/generic-names/-/generic-names-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
 			"integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
 			"dev": true,
 			"requires": {
@@ -7928,19 +7941,19 @@
 			"dependencies": {
 				"big.js": {
 					"version": "3.2.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/big.js/-/big.js-3.2.0.tgz",
-					"integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
+					"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+					"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
 					"dev": true
 				},
 				"json5": {
 					"version": "0.5.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/json5/-/json5-0.5.1.tgz",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 					"dev": true
 				},
 				"loader-utils": {
 					"version": "0.2.17",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/loader-utils/-/loader-utils-0.2.17.tgz",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"dev": true,
 					"requires": {
@@ -7957,22 +7970,6 @@
 			"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
 			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
 			"dev": true
-		},
-		"gentle-fs": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
-			"integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
-			"dev": true,
-			"requires": {
-				"aproba": "^1.1.2",
-				"fs-vacuum": "^1.2.10",
-				"graceful-fs": "^4.1.11",
-				"iferr": "^0.1.5",
-				"mkdirp": "^0.5.1",
-				"path-is-inside": "^1.0.2",
-				"read-cmd-shim": "^1.0.1",
-				"slide": "^1.1.6"
-			}
 		},
 		"get-caller-file": {
 			"version": "1.0.3",
@@ -8162,6 +8159,25 @@
 				"semver": "^5.5.0"
 			}
 		},
+		"git-up": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+			"integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"parse-url": "^5.0.0"
+			}
+		},
+		"git-url-parse": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+			"integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+			"dev": true,
+			"requires": {
+				"git-up": "^4.0.0"
+			}
+		},
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
@@ -8259,12 +8275,6 @@
 				"resolve-dir": "^1.0.0"
 			}
 		},
-		"global-modules-path": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/global-modules-path/-/global-modules-path-2.3.1.tgz",
-			"integrity": "sha512-y+shkf4InI7mPRHSo2b/k6ix6+NLDtyccYv86whhxrSGX9wjPX1VMITmrDbE1eh7zkzhiWtW2sHklJYoQ62Cxg==",
-			"dev": true
-		},
 		"global-prefix": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
@@ -8279,9 +8289,9 @@
 			}
 		},
 		"globals": {
-			"version": "11.10.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-			"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
 			"dev": true
 		},
 		"globby": {
@@ -8408,9 +8418,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.0.12",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+			"integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
 			"dev": true,
 			"requires": {
 				"async": "^2.5.0",
@@ -8545,8 +8555,8 @@
 		},
 		"hex-color-regex": {
 			"version": "1.1.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-			"integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4=",
+			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
 			"dev": true
 		},
 		"hmac-drbg": {
@@ -8577,9 +8587,9 @@
 			}
 		},
 		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
@@ -8611,13 +8621,13 @@
 		},
 		"hsl-regex": {
 			"version": "1.0.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/hsl-regex/-/hsl-regex-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
 			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
 			"dev": true
 		},
 		"hsla-regex": {
 			"version": "1.0.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/hsla-regex/-/hsla-regex-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
 			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
@@ -8705,15 +8715,15 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
-			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+			"integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
 			"dev": true,
 			"requires": {
-				"http-proxy": "^1.16.2",
+				"http-proxy": "^1.17.0",
 				"is-glob": "^4.0.0",
-				"lodash": "^4.17.5",
-				"micromatch": "^3.1.9"
+				"lodash": "^4.17.11",
+				"micromatch": "^3.1.10"
 			}
 		},
 		"http-signature": {
@@ -8933,7 +8943,7 @@
 		},
 		"import-cwd": {
 			"version": "2.1.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/import-cwd/-/import-cwd-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
 			"integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
 			"dev": true,
 			"requires": {
@@ -8952,7 +8962,7 @@
 		},
 		"import-from": {
 			"version": "2.1.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/import-from/-/import-from-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
 			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
 			"dev": true,
 			"requires": {
@@ -9104,13 +9114,21 @@
 			}
 		},
 		"internal-ip": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
-			"integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.2.0.tgz",
+			"integrity": "sha512-ZY8Rk+hlvFeuMmG5uH1MXhhdeMntmIaxaInvAmzMq/SHV8rv4Kh+6GiQNNDQd0wZFrcO+FiTBo8lui/osKOyJw==",
 			"dev": true,
 			"requires": {
-				"default-gateway": "^2.6.0",
-				"ipaddr.js": "^1.5.2"
+				"default-gateway": "^4.0.1",
+				"ipaddr.js": "^1.9.0"
+			},
+			"dependencies": {
+				"ipaddr.js": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+					"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+					"dev": true
+				}
 			}
 		},
 		"interpret": {
@@ -9205,15 +9223,6 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
-			"requires": {
-				"builtin-modules": "^1.0.0"
-			}
-		},
 		"is-callable": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -9231,7 +9240,7 @@
 		},
 		"is-color-stop": {
 			"version": "1.1.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-color-stop/-/is-color-stop-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
 			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
 			"dev": true,
 			"requires": {
@@ -9464,6 +9473,15 @@
 			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
 			"dev": true
 		},
+		"is-ssh": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+			"integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+			"dev": true,
+			"requires": {
+				"protocols": "^1.1.0"
+			}
+		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -9618,9 +9636,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+			"integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -9787,12 +9805,6 @@
 				"webpack-sources": "^1.1.0"
 			}
 		},
-		"lave": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/lave/-/lave-1.1.10.tgz",
-			"integrity": "sha1-BiIHZSxVAtfG/wlsneOZVAH2NNU=",
-			"dev": true
-		},
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -9809,28 +9821,28 @@
 			}
 		},
 		"lerna": {
-			"version": "3.10.7",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.10.7.tgz",
-			"integrity": "sha512-ha/dehl/L3Nw0pbdir5z6Hrv2oYBg5ym2fTcuk8HCLe7Zdb/ylIHdrgW8CU9eTVZkwr4et8RdVtxFA/+xa65/Q==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.13.1.tgz",
+			"integrity": "sha512-7kSz8LLozVsoUNTJzJzy+b8TnV9YdviR2Ee2PwGZSlVw3T1Rn7kOAPZjEi+3IWnOPC96zMPHVmjCmzQ4uubalw==",
 			"dev": true,
 			"requires": {
-				"@lerna/add": "3.10.6",
-				"@lerna/bootstrap": "3.10.6",
-				"@lerna/changed": "3.10.6",
-				"@lerna/clean": "3.10.6",
-				"@lerna/cli": "3.10.7",
-				"@lerna/create": "3.10.6",
-				"@lerna/diff": "3.10.6",
-				"@lerna/exec": "3.10.6",
-				"@lerna/import": "3.10.6",
-				"@lerna/init": "3.10.6",
-				"@lerna/link": "3.10.6",
-				"@lerna/list": "3.10.6",
-				"@lerna/publish": "3.10.7",
-				"@lerna/run": "3.10.6",
-				"@lerna/version": "3.10.6",
+				"@lerna/add": "3.13.1",
+				"@lerna/bootstrap": "3.13.1",
+				"@lerna/changed": "3.13.1",
+				"@lerna/clean": "3.13.1",
+				"@lerna/cli": "3.13.0",
+				"@lerna/create": "3.13.1",
+				"@lerna/diff": "3.13.1",
+				"@lerna/exec": "3.13.1",
+				"@lerna/import": "3.13.1",
+				"@lerna/init": "3.13.1",
+				"@lerna/link": "3.13.1",
+				"@lerna/list": "3.13.1",
+				"@lerna/publish": "3.13.1",
+				"@lerna/run": "3.13.1",
+				"@lerna/version": "3.13.1",
 				"import-local": "^1.0.0",
-				"libnpm": "^2.0.1"
+				"npmlog": "^4.1.2"
 			}
 		},
 		"lerna-packages": {
@@ -10079,34 +10091,6 @@
 				"type-check": "~0.3.2"
 			}
 		},
-		"libnpm": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/libnpm/-/libnpm-2.0.1.tgz",
-			"integrity": "sha512-qTKoxyJvpBxHZQB6k0AhSLajyXq9ZE/lUsZzuHAplr2Bpv9G+k4YuYlExYdUCeVRRGqcJt8hvkPh4tBwKoV98w==",
-			"dev": true,
-			"requires": {
-				"bin-links": "^1.1.2",
-				"bluebird": "^3.5.3",
-				"find-npm-prefix": "^1.0.2",
-				"libnpmaccess": "^3.0.1",
-				"libnpmconfig": "^1.2.1",
-				"libnpmhook": "^5.0.2",
-				"libnpmorg": "^1.0.0",
-				"libnpmpublish": "^1.1.0",
-				"libnpmsearch": "^2.0.0",
-				"libnpmteam": "^1.0.1",
-				"lock-verify": "^2.0.2",
-				"npm-lifecycle": "^2.1.0",
-				"npm-logical-tree": "^1.2.1",
-				"npm-package-arg": "^6.1.0",
-				"npm-profile": "^4.0.1",
-				"npm-registry-fetch": "^3.8.0",
-				"npmlog": "^4.1.2",
-				"pacote": "^9.2.3",
-				"read-package-json": "^2.0.13",
-				"stringify-package": "^1.0.0"
-			}
-		},
 		"libnpmaccess": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz",
@@ -10116,102 +10100,6 @@
 				"aproba": "^2.0.0",
 				"get-stream": "^4.0.0",
 				"npm-package-arg": "^6.1.0",
-				"npm-registry-fetch": "^3.8.0"
-			},
-			"dependencies": {
-				"aproba": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-					"dev": true
-				}
-			}
-		},
-		"libnpmconfig": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
-			"integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
-			"dev": true,
-			"requires": {
-				"figgy-pudding": "^3.5.1",
-				"find-up": "^3.0.0",
-				"ini": "^1.3.5"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-					"dev": true
-				}
-			}
-		},
-		"libnpmhook": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.2.tgz",
-			"integrity": "sha512-vLenmdFWhRfnnZiNFPNMog6CK7Ujofy2TWiM2CrpZUjBRIhHkJeDaAbJdYCT6W4lcHtyrJR8yXW8KFyq6UAp1g==",
-			"dev": true,
-			"requires": {
-				"aproba": "^2.0.0",
-				"figgy-pudding": "^3.4.1",
-				"get-stream": "^4.0.0",
-				"npm-registry-fetch": "^3.8.0"
-			},
-			"dependencies": {
-				"aproba": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-					"dev": true
-				}
-			}
-		},
-		"libnpmorg": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.0.tgz",
-			"integrity": "sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==",
-			"dev": true,
-			"requires": {
-				"aproba": "^2.0.0",
-				"figgy-pudding": "^3.4.1",
-				"get-stream": "^4.0.0",
 				"npm-registry-fetch": "^3.8.0"
 			},
 			"dependencies": {
@@ -10256,43 +10144,6 @@
 					}
 				}
 			}
-		},
-		"libnpmsearch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.0.tgz",
-			"integrity": "sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==",
-			"dev": true,
-			"requires": {
-				"figgy-pudding": "^3.5.1",
-				"get-stream": "^4.0.0",
-				"npm-registry-fetch": "^3.8.0"
-			}
-		},
-		"libnpmteam": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.1.tgz",
-			"integrity": "sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==",
-			"dev": true,
-			"requires": {
-				"aproba": "^2.0.0",
-				"figgy-pudding": "^3.4.1",
-				"get-stream": "^4.0.0",
-				"npm-registry-fetch": "^3.8.0"
-			},
-			"dependencies": {
-				"aproba": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-					"dev": true
-				}
-			}
-		},
-		"lightercollective": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.1.0.tgz",
-			"integrity": "sha512-J9tg5uraYoQKaWbmrzDDexbG6hHnMcWS1qLYgJSWE+mpA3U5OCSeMUhb+K55otgZJ34oFdR0ECvdIb3xuO5JOQ==",
-			"dev": true
 		},
 		"load-json-file": {
 			"version": "1.1.0",
@@ -10362,16 +10213,6 @@
 				"path-exists": "^3.0.0"
 			}
 		},
-		"lock-verify": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.2.tgz",
-			"integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
-			"dev": true,
-			"requires": {
-				"npm-package-arg": "^5.1.2 || 6",
-				"semver": "^5.4.1"
-			}
-		},
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -10402,12 +10243,6 @@
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
 		},
-		"lodash.debounce": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-			"dev": true
-		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -10430,6 +10265,12 @@
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
 			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+			"dev": true
+		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -10529,12 +10370,12 @@
 			"dev": true
 		},
 		"magic-string": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
-			"integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+			"integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
 			"dev": true,
 			"requires": {
-				"sourcemap-codec": "^1.4.1"
+				"sourcemap-codec": "^1.4.4"
 			}
 		},
 		"make-dir": {
@@ -10650,6 +10491,12 @@
 					"dev": true
 				}
 			}
+		},
+		"mamacro": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+			"dev": true
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -10903,18 +10750,18 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+			"version": "2.1.22",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "~1.38.0"
 			}
 		},
 		"mimic-fn": {
@@ -11288,33 +11135,18 @@
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
-				"events": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-					"dev": true
-				},
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
-				},
-				"util": {
-					"version": "0.10.4",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-					"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
 				}
 			}
 		},
 		"node-releases": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.6.tgz",
-			"integrity": "sha512-lODUVHEIZutZx+TDdOk47qLik8FJMXzJ+WnyUGci1MTvTOyzZrz5eVPIIpc5Hb3NfHZGeGHeuwrRYVI1PEITWg==",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.8.tgz",
+			"integrity": "sha512-gQm+K9mGCiT/NXHy+V/ZZS1N/LOaGGqRAAJJs3X9Ah1g+CIbRcBgNyoNYQ+SEtcyAtB9KqDruu+fF7nWjsqRaA==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -11480,25 +11312,22 @@
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
-			"integrity": "sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
+				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"normalize-range": {
 			"version": "0.1.2",
@@ -11519,9 +11348,9 @@
 			}
 		},
 		"npm-bundled": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
-			"integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 			"dev": true
 		},
 		"npm-lifecycle": {
@@ -11548,12 +11377,6 @@
 				}
 			}
 		},
-		"npm-logical-tree": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
-			"integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
-			"dev": true
-		},
 		"npm-package-arg": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
@@ -11567,9 +11390,9 @@
 			}
 		},
 		"npm-packlist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
-			"integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+			"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 			"dev": true,
 			"requires": {
 				"ignore-walk": "^3.0.1",
@@ -11585,17 +11408,6 @@
 				"figgy-pudding": "^3.5.1",
 				"npm-package-arg": "^6.0.0",
 				"semver": "^5.4.1"
-			}
-		},
-		"npm-profile": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.1.tgz",
-			"integrity": "sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==",
-			"dev": true,
-			"requires": {
-				"aproba": "^1.1.2 || 2",
-				"figgy-pudding": "^3.4.1",
-				"npm-registry-fetch": "^3.8.0"
 			}
 		},
 		"npm-registry-fetch": {
@@ -11655,9 +11467,9 @@
 			"dev": true
 		},
 		"nwsapi": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+			"integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
 			"dev": true
 		},
 		"oauth-sign": {
@@ -11704,9 +11516,9 @@
 			}
 		},
 		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+			"integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
 			"dev": true
 		},
 		"object-visit": {
@@ -11795,6 +11607,12 @@
 			"integrity": "sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws=",
 			"dev": true
 		},
+		"octokit-pagination-methods": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+			"dev": true
+		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -11805,9 +11623,9 @@
 			}
 		},
 		"on-headers": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
 			"dev": true
 		},
 		"once": {
@@ -12011,8 +11829,8 @@
 		},
 		"p-queue": {
 			"version": "2.4.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-queue/-/p-queue-2.4.2.tgz",
-			"integrity": "sha1-A2CYJmgrdDvpoi26JQUb1Gck/DQ=",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+			"integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==",
 			"dev": true
 		},
 		"p-reduce": {
@@ -12037,9 +11855,9 @@
 			}
 		},
 		"pacote": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.4.1.tgz",
-			"integrity": "sha512-YKSRsQqmeHxgra0KCdWA2FtVxDPUlBiCdmew+mSe44pzlx5t1ViRMWiQg18T+DREA+vSqYfKzynaToFR4hcKHw==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.0.tgz",
+			"integrity": "sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.3",
@@ -12180,9 +11998,9 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
-			"integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+			"integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
 			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
@@ -12243,6 +12061,36 @@
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
+		},
+		"parse-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+			"integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"protocols": "^1.4.0"
+			}
+		},
+		"parse-url": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+			"integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"normalize-url": "^3.3.0",
+				"parse-path": "^4.0.0",
+				"protocols": "^1.4.0"
+			},
+			"dependencies": {
+				"normalize-url": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+					"dev": true
+				}
+			}
 		},
 		"parse5": {
 			"version": "5.1.0",
@@ -12622,8 +12470,8 @@
 		},
 		"postcss-load-config": {
 			"version": "2.0.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-			"integrity": "sha1-8TEt2/WRLNdHF3CDxe96GdYu5IQ=",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
+			"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^4.0.0",
@@ -12632,8 +12480,8 @@
 			"dependencies": {
 				"cosmiconfig": {
 					"version": "4.0.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-					"integrity": "sha1-dgORVJWAu9LfHlYrwXexPCkJctw=",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+					"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
 					"dev": true,
 					"requires": {
 						"is-directory": "^0.3.1",
@@ -12742,8 +12590,8 @@
 		},
 		"postcss-modules": {
 			"version": "1.4.1",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-modules/-/postcss-modules-1.4.1.tgz",
-			"integrity": "sha1-iqNb00Ydtn4nN3p853DXe2VKhO8=",
+			"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-1.4.1.tgz",
+			"integrity": "sha512-btTrbK+Xc3NBuYF8TPBjCMRSp5h6NoQ1iVZ6WiDQENIze6KIYCSf0+UFQuV3yJ7gRHA+4AAtF8i2jRvUpbBMMg==",
 			"dev": true,
 			"requires": {
 				"css-modules-loader-core": "^1.1.0",
@@ -12766,14 +12614,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -12907,8 +12755,8 @@
 		},
 		"postcss-normalize-display-values": {
 			"version": "4.0.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
-			"integrity": "sha1-Db4EpM6QY9RmftK+R2u4MMglk1o=",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+			"integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
 			"dev": true,
 			"requires": {
 				"cssnano-util-get-match": "^4.0.0",
@@ -12918,8 +12766,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -12929,14 +12777,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -12946,8 +12794,8 @@
 		},
 		"postcss-normalize-positions": {
 			"version": "4.0.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
-			"integrity": "sha1-BfdX+E8mBDc3g2ipH4ky1LECkX8=",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+			"integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
 			"dev": true,
 			"requires": {
 				"cssnano-util-get-arguments": "^4.0.0",
@@ -12958,8 +12806,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -12969,14 +12817,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -12986,8 +12834,8 @@
 		},
 		"postcss-normalize-repeat-style": {
 			"version": "4.0.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
-			"integrity": "sha1-xOu8KJ85kaAo1EdRy90RkYsXkQw=",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+			"integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
 			"dev": true,
 			"requires": {
 				"cssnano-util-get-arguments": "^4.0.0",
@@ -12998,8 +12846,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13009,14 +12857,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -13026,8 +12874,8 @@
 		},
 		"postcss-normalize-string": {
 			"version": "4.0.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
-			"integrity": "sha1-zUTECrB6DHo23F6Zqs4eyk7CaQw=",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+			"integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.0",
@@ -13037,8 +12885,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13048,14 +12896,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -13065,8 +12913,8 @@
 		},
 		"postcss-normalize-timing-functions": {
 			"version": "4.0.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
-			"integrity": "sha1-jgCcoqOUnNr4rSPmtquZy159KNk=",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+			"integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
 			"dev": true,
 			"requires": {
 				"cssnano-util-get-match": "^4.0.0",
@@ -13076,8 +12924,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13087,14 +12935,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -13104,8 +12952,8 @@
 		},
 		"postcss-normalize-unicode": {
 			"version": "4.0.1",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
-			"integrity": "sha1-hBvUj9zzAZrUuqdJOj02O1KuHPs=",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+			"integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.0.0",
@@ -13115,8 +12963,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13126,14 +12974,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -13141,7 +12989,6 @@
 				}
 			}
 		},
-
 		"postcss-normalize-url": {
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
@@ -13156,8 +13003,8 @@
 		},
 		"postcss-normalize-whitespace": {
 			"version": "4.0.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
-			"integrity": "sha1-vx1AcP5Pzqh9E0joJdjMDF+qfYI=",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+			"integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0",
@@ -13166,8 +13013,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13177,14 +13024,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -13386,9 +13233,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-			"integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
+			"version": "1.16.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+			"integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -13448,7 +13295,7 @@
 		},
 		"promise.series": {
 			"version": "0.2.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/promise.series/-/promise.series-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
 			"integrity": "sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=",
 			"dev": true
 		},
@@ -13485,19 +13332,26 @@
 			}
 		},
 		"prop-types": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
 			}
 		},
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+			"dev": true
+		},
+		"protocols": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
 			"dev": true
 		},
 		"protoduck": {
@@ -13650,9 +13504,9 @@
 			}
 		},
 		"randombytes": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
@@ -13696,6 +13550,12 @@
 					}
 				}
 			}
+		},
+		"react-is": {
+			"version": "16.8.3",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
+			"integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
+			"dev": true
 		},
 		"react-svg-core": {
 			"version": "2.1.0",
@@ -13853,9 +13713,9 @@
 			}
 		},
 		"read-package-tree": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.1.tgz",
-			"integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz",
+			"integrity": "sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==",
 			"dev": true,
 			"requires": {
 				"debuglog": "^1.0.1",
@@ -14022,9 +13882,9 @@
 			"dev": true
 		},
 		"regenerator-transform": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
-			"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+			"integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
 			"dev": true,
 			"requires": {
 				"private": "^0.1.6"
@@ -14172,23 +14032,23 @@
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "^4.17.11"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
 			}
 		},
 		"require-directory": {
@@ -14199,8 +14059,8 @@
 		},
 		"require-from-string": {
 			"version": "2.0.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true
 		},
 		"require-main-filename": {
@@ -14256,7 +14116,7 @@
 		},
 		"reserved-words": {
 			"version": "0.1.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/reserved-words/-/reserved-words-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
 			"integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
 			"dev": true
 		},
@@ -14330,13 +14190,13 @@
 		},
 		"rgb-regex": {
 			"version": "1.0.1",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/rgb-regex/-/rgb-regex-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
 			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
 			"dev": true
 		},
 		"rgba-regex": {
 			"version": "1.0.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/rgba-regex/-/rgba-regex-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
 			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
 			"dev": true
 		},
@@ -14360,14 +14220,14 @@
 			}
 		},
 		"rollup": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.1.2.tgz",
-			"integrity": "sha512-OkdMxqMl8pWoQc5D8y1cIinYQPPLV8ZkfLgCzL6SytXeNA2P7UHynEQXI9tYxuAjAMsSyvRaWnyJDLHMxq0XAg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.3.1.tgz",
+			"integrity": "sha512-XaVp/ggPVQ3zD4wktUzJo0XGbsnRHsGWk4B4497hE35emWods/WkrIEVgoLRSvMSxCpklLPBfWZAiTs/VeFSNg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*",
-				"acorn": "^6.0.5"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.0"
 			}
 		},
 		"rollup-plugin-analyzer": {
@@ -14387,25 +14247,33 @@
 			}
 		},
 		"rollup-plugin-commonjs": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.0.tgz",
-			"integrity": "sha512-0RM5U4Vd6iHjL6rLvr3lKBwnPsaVml+qxOGaaNUWN1lSq6S33KhITOfHmvxV3z2vy9Mk4t0g4rNlVaJJsNQPWA==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.1.tgz",
+			"integrity": "sha512-X0A/Cp/t+zbONFinBhiTZrfuUaVwRIp4xsbKq/2ohA2CDULa/7ONSJTelqxon+Vds2R2t2qJTqJQucKUC8GKkw==",
 			"dev": true,
 			"requires": {
 				"estree-walker": "^0.5.2",
 				"magic-string": "^0.25.1",
-				"resolve": "^1.8.1",
+				"resolve": "^1.10.0",
 				"rollup-pluginutils": "^2.3.3"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+					"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+					"dev": true
+				}
 			}
 		},
 		"rollup-plugin-image-files": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-image-files/-/rollup-plugin-image-files-1.2.0.tgz",
-			"integrity": "sha512-9iAbp8KLKPsUWEYKM1PdQXuw1k7kNbogC6s0qqGL7UnlS+ssOo6yI8Vxc5my9uhJFA1TjzRSs+G429YoSipEhg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-image-files/-/rollup-plugin-image-files-1.3.0.tgz",
+			"integrity": "sha512-O2KPvwmXCdvxxZZB1EAX/Zyt9iC0KvjBOYIL25hVojcMme4QqVmTZKF/z3UiwMli/TWe5QBeDkHQg8NVR+fEDA==",
 			"dev": true,
 			"requires": {
-				"rollup": "^0.64.1",
-				"rollup-pluginutils": "^2.3.1"
+				"rollup": "0.64.1",
+				"rollup-pluginutils": "2.4.1"
 			},
 			"dependencies": {
 				"rollup": {
@@ -14461,6 +14329,12 @@
 					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
 					"dev": true
 				},
+				"estree-walker": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+					"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+					"dev": true
+				},
 				"magic-string": {
 					"version": "0.22.5",
 					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
@@ -14473,28 +14347,20 @@
 			}
 		},
 		"rollup-plugin-node-resolve": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.0.tgz",
-			"integrity": "sha512-7Ni+/M5RPSUBfUaP9alwYQiIKnKeXCOHiqBpKUl9kwp3jX5ZJtgXAait1cne6pGEVUUztPD6skIKH9Kq9sNtfw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz",
+			"integrity": "sha512-fSS7YDuCe0gYqKsr5OvxMloeZYUSgN43Ypi1WeRZzQcWtHgFayV5tUSPYpxuaioIIWaBXl6NrVk0T2/sKwueLg==",
 			"dev": true,
 			"requires": {
 				"builtin-modules": "^3.0.0",
 				"is-module": "^1.0.0",
-				"resolve": "^1.8.1"
-			},
-			"dependencies": {
-				"builtin-modules": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
-					"integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
-					"dev": true
-				}
+				"resolve": "^1.10.0"
 			}
 		},
 		"rollup-plugin-postcss": {
 			"version": "2.0.3",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/rollup-plugin-postcss/-/rollup-plugin-postcss-2.0.3.tgz",
-			"integrity": "sha1-H9W34fx1RcsAhNnJnRGyWeQaBeY=",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-2.0.3.tgz",
+			"integrity": "sha512-d12oKl6za/GGXmlytzVPzzTdPCKgti/Kq2kNhtfm5vv9hkNbyrTvizMBm6zZ5rRWX/sIWl3znjIJ8xy6Hofoeg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -14515,8 +14381,8 @@
 			"dependencies": {
 				"cssnano": {
 					"version": "4.1.10",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cssnano/-/cssnano-4.1.10.tgz",
-					"integrity": "sha1-CsQfCxPRPUZUh+ERt3jULaYxuLI=",
+					"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
+					"integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
 					"dev": true,
 					"requires": {
 						"cosmiconfig": "^5.0.0",
@@ -14527,14 +14393,14 @@
 				},
 				"pify": {
 					"version": "3.0.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pify/-/pify-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				},
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -14544,14 +14410,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -14571,15 +14437,14 @@
 			}
 		},
 		"rollup-plugin-terser": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.3.tgz",
-			"integrity": "sha512-XJ9l7/SaNxiK5EfqYaMnMzCbnlXhxRUTm/U0O+4Nl03wTvidrotHokl+3Po/F5jnChtHseszehFpV4m0WpsrqA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
+			"integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"escodegen": "^1.11.0",
 				"jest-worker": "^24.0.0",
-				"lave": "^1.1.10",
+				"serialize-javascript": "^1.6.1",
 				"terser": "^3.14.1"
 			}
 		},
@@ -14604,104 +14469,13 @@
 			}
 		},
 		"rollup-pluginutils": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
-			"integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz",
+			"integrity": "sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==",
 			"dev": true,
 			"requires": {
-				"estree-walker": "^0.5.2",
-				"micromatch": "^2.3.11"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
-				}
+				"estree-walker": "^0.6.0",
+				"micromatch": "^3.1.10"
 			}
 		},
 		"run-async": {
@@ -14898,9 +14672,9 @@
 			"dev": true
 		},
 		"saxes": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.6.tgz",
-			"integrity": "sha512-LAYs+lChg1v5uKNzPtsgTxSS5hLo8aIhSMCJt1WMpefAxm3D1RTpMwSpb6ebdL31cubiLTnhokVktBW+cv9Y9w==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.9.tgz",
+			"integrity": "sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==",
 			"dev": true,
 			"requires": {
 				"xmlchars": "^1.3.1"
@@ -14918,9 +14692,9 @@
 			},
 			"dependencies": {
 				"ajv-keywords": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
-					"integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+					"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
 					"dev": true
 				}
 			}
@@ -15138,7 +14912,7 @@
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
 			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
 			"dev": true,
 			"requires": {
@@ -15147,8 +14921,8 @@
 			"dependencies": {
 				"is-arrayish": {
 					"version": "0.3.2",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-arrayish/-/is-arrayish-0.3.2.tgz",
-					"integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
 					"dev": true
 				}
 			}
@@ -15709,7 +15483,7 @@
 		},
 		"string-hash": {
 			"version": "1.1.3",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/string-hash/-/string-hash-1.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
 			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
 			"dev": true
 		},
@@ -15738,12 +15512,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
-		},
-		"stringify-package": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
-			"integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
-			"dev": true
 		},
 		"stringstream": {
 			"version": "0.0.6",
@@ -15808,8 +15576,8 @@
 		},
 		"style-inject": {
 			"version": "0.3.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/style-inject/-/style-inject-0.3.0.tgz",
-			"integrity": "sha1-0hxHev/skYEcyCNVgypwDSK/jdM=",
+			"resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
+			"integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==",
 			"dev": true
 		},
 		"style-loader": {
@@ -15823,9 +15591,9 @@
 			},
 			"dependencies": {
 				"ajv-keywords": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
-					"integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+					"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
 					"dev": true
 				},
 				"schema-utils": {
@@ -15842,8 +15610,8 @@
 		},
 		"stylehacks": {
 			"version": "4.0.3",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/stylehacks/-/stylehacks-4.0.3.tgz",
-			"integrity": "sha1-Zxj8r00eB9ihMYaQiB6NlnJqcdU=",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+			"integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.0.0",
@@ -15853,8 +15621,8 @@
 			"dependencies": {
 				"postcss": {
 					"version": "7.0.14",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -15864,7 +15632,7 @@
 				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
 					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
 					"dev": true,
 					"requires": {
@@ -15875,14 +15643,14 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
-					"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -16137,6 +15905,40 @@
 				"@octokit/rest": "^15.4.0",
 				"commander": "^2.14.1",
 				"surge": "^0.20.0"
+			},
+			"dependencies": {
+				"@octokit/rest": {
+					"version": "15.18.1",
+					"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.18.1.tgz",
+					"integrity": "sha512-g2tecjp2TEtYV8bKAFvfQtu+W29HM7ektmWmw8zrMy9/XCKDEYRErR2YvvhN9+IxkLC4O3lDqYP4b6WgsL6Utw==",
+					"dev": true,
+					"requires": {
+						"before-after-hook": "^1.1.0",
+						"btoa-lite": "^1.0.0",
+						"debug": "^3.1.0",
+						"http-proxy-agent": "^2.1.0",
+						"https-proxy-agent": "^2.2.0",
+						"lodash": "^4.17.4",
+						"node-fetch": "^2.1.1",
+						"universal-user-agent": "^2.0.0",
+						"url-template": "^2.0.8"
+					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
 			}
 		},
 		"surge-ignore": {
@@ -16146,23 +15948,23 @@
 			"dev": true
 		},
 		"svgo": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
-			"integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.0.tgz",
+			"integrity": "sha512-xBfxJxfk4UeVN8asec9jNxHiv3UAMv/ujwBWGYvQhhMb2u3YTGKkiybPcLFDLq7GLLWE9wa73e0/m8L5nTzQbw==",
 			"dev": true,
 			"requires": {
-				"coa": "~2.0.1",
-				"colors": "~1.1.2",
+				"chalk": "^2.4.1",
+				"coa": "^2.0.2",
 				"css-select": "^2.0.0",
-				"css-select-base-adapter": "~0.1.0",
+				"css-select-base-adapter": "^0.1.1",
 				"css-tree": "1.0.0-alpha.28",
 				"css-url-regex": "^1.1.0",
-				"csso": "^3.5.0",
+				"csso": "^3.5.1",
 				"js-yaml": "^3.12.0",
 				"mkdirp": "~0.5.1",
-				"object.values": "^1.0.4",
+				"object.values": "^1.1.0",
 				"sax": "~1.2.4",
-				"stable": "~0.1.6",
+				"stable": "^0.1.8",
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
 			}
@@ -16301,14 +16103,14 @@
 			}
 		},
 		"terser": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
-			"integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
+			"version": "3.16.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-3.16.1.tgz",
+			"integrity": "sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==",
 			"dev": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.6"
+				"source-map-support": "~0.5.9"
 			},
 			"dependencies": {
 				"commander": {
@@ -16336,9 +16138,9 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz",
-			"integrity": "sha512-GGSt+gbT0oKcMDmPx4SRSfJPE1XaN3kQRWG4ghxKQw9cn5G9x6aCKSsgYdvyM0na9NJ4Drv0RG6jbBByZ5CMjw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+			"integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
 			"dev": true,
 			"requires": {
 				"cacache": "^11.0.2",
@@ -16346,7 +16148,7 @@
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.4.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.8.1",
+				"terser": "^3.16.1",
 				"webpack-sources": "^1.1.0",
 				"worker-farm": "^1.5.2"
 			},
@@ -16534,6 +16336,15 @@
 						"parse-glob": "^3.0.4",
 						"regex-cache": "^0.4.2"
 					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
 				}
 			}
 		},
@@ -16582,7 +16393,7 @@
 		},
 		"timsort": {
 			"version": "0.3.0",
-			"resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/timsort/-/timsort-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
 			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
 		},
@@ -16809,9 +16620,9 @@
 			},
 			"dependencies": {
 				"ajv-keywords": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
-					"integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+					"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
 					"dev": true
 				},
 				"commander": {
@@ -17319,15 +17130,15 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "4.29.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.0.tgz",
-			"integrity": "sha512-pxdGG0keDBtamE1mNvT5zyBdx+7wkh6mh7uzMOo/uRQ/fhsdj5FXkh/j5mapzs060forql1oXqXN9HJGju+y7w==",
+			"version": "4.29.5",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.5.tgz",
+			"integrity": "sha512-DuWlYUT982c7XVHodrLO9quFbNpVq5FNxLrMUfYUTlgKW0+yPimynYf1kttSQpEneAL1FH3P3OLNgkyImx8qIQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-module-context": "1.7.11",
-				"@webassemblyjs/wasm-edit": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11",
+				"@webassemblyjs/ast": "1.8.3",
+				"@webassemblyjs/helper-module-context": "1.8.3",
+				"@webassemblyjs/wasm-edit": "1.8.3",
+				"@webassemblyjs/wasm-parser": "1.8.3",
 				"acorn": "^6.0.5",
 				"acorn-dynamic-import": "^4.0.0",
 				"ajv": "^6.1.0",
@@ -17343,7 +17154,7 @@
 				"mkdirp": "~0.5.0",
 				"neo-async": "^2.5.0",
 				"node-libs-browser": "^2.0.0",
-				"schema-utils": "^0.4.4",
+				"schema-utils": "^1.0.0",
 				"tapable": "^1.1.0",
 				"terser-webpack-plugin": "^1.1.0",
 				"watchpack": "^1.5.0",
@@ -17351,9 +17162,9 @@
 			},
 			"dependencies": {
 				"ajv-keywords": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
-					"integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+					"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
 					"dev": true
 				},
 				"eslint-scope": {
@@ -17365,23 +17176,13 @@
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
 					}
-				},
-				"schema-utils": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-					"dev": true,
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
-					}
 				}
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.3.tgz",
-			"integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.4.tgz",
+			"integrity": "sha512-ggDUgtKuQki4vmc93Ej65GlYxeCUR/0THa7gA+iqAGC2FFAxO+r+RM9sAUa8HWdw4gJ3/NZHX/QUcVgRjdIsDg==",
 			"dev": true,
 			"requires": {
 				"acorn": "^5.7.3",
@@ -17407,9 +17208,9 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.2.1.tgz",
-			"integrity": "sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.2.3.tgz",
+			"integrity": "sha512-Ik3SjV6uJtWIAN5jp5ZuBMWEAaP5E4V78XJ2nI+paFPh8v4HPSwo/myN0r29Xc/6ZKnd2IdrAlpSgNOu2CDQ6Q==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
@@ -17417,10 +17218,8 @@
 				"enhanced-resolve": "^4.1.0",
 				"findup-sync": "^2.0.0",
 				"global-modules": "^1.0.0",
-				"global-modules-path": "^2.3.0",
 				"import-local": "^2.0.0",
 				"interpret": "^1.1.0",
-				"lightercollective": "^0.1.0",
 				"loader-utils": "^1.1.0",
 				"supports-color": "^5.5.0",
 				"v8-compile-cache": "^2.0.2",
@@ -17600,12 +17399,12 @@
 			}
 		},
 		"webpack-dev-middleware": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
-			"integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.0.tgz",
+			"integrity": "sha512-oeXA3m+5gbYbDBGo4SvKpAHJJEGMoekUbHgo1RK7CP1sz7/WOSeu/dWJtSTk+rzDCLkPwQhGocgIq6lQqOyOwg==",
 			"dev": true,
 			"requires": {
-				"memory-fs": "~0.4.1",
+				"memory-fs": "^0.4.1",
 				"mime": "^2.3.1",
 				"range-parser": "^1.0.3",
 				"webpack-log": "^2.0.0"
@@ -17620,9 +17419,9 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.1.14",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
-			"integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
+			"integrity": "sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==",
 			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
@@ -17630,13 +17429,13 @@
 				"chokidar": "^2.0.0",
 				"compression": "^1.5.2",
 				"connect-history-api-fallback": "^1.3.0",
-				"debug": "^3.1.0",
+				"debug": "^4.1.1",
 				"del": "^3.0.0",
 				"express": "^4.16.2",
 				"html-entities": "^1.2.0",
-				"http-proxy-middleware": "~0.18.0",
+				"http-proxy-middleware": "^0.19.1",
 				"import-local": "^2.0.0",
-				"internal-ip": "^3.0.1",
+				"internal-ip": "^4.2.0",
 				"ip": "^1.1.5",
 				"killable": "^1.0.0",
 				"loglevel": "^1.4.1",
@@ -17650,9 +17449,9 @@
 				"sockjs-client": "1.3.0",
 				"spdy": "^4.0.0",
 				"strip-ansi": "^3.0.0",
-				"supports-color": "^5.1.0",
+				"supports-color": "^6.1.0",
 				"url": "^0.11.0",
-				"webpack-dev-middleware": "3.4.0",
+				"webpack-dev-middleware": "^3.5.1",
 				"webpack-log": "^2.0.0",
 				"yargs": "12.0.2"
 			},
@@ -17692,9 +17491,9 @@
 					}
 				},
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -17819,6 +17618,15 @@
 								"ansi-regex": "^3.0.0"
 							}
 						}
+					}
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				},
 				"which-module": {
@@ -18157,9 +17965,9 @@
 			}
 		},
 		"ws": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
-			"integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+			"integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
 			"dev": true,
 			"requires": {
 				"async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.0.4",
     "webpack-dev-server": "^3.1.14",
-    "webpack-merge": "^4.1.2"
+    "webpack-merge": "^4.1.2",
+    "dotenv": "^6.2.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,10 @@ import cloneDeep from 'lodash/cloneDeep';
 import images from 'rollup-plugin-image-files';
 import nodeGlobalsPolyfill from 'rollup-plugin-node-globals';
 import { externals, globals, excludedExternals, excludedGlobals } from './rollup.externals';
+import dotenv from 'dotenv';
+
+const rootPath = path.resolve(__dirname + '/.env');
+dotenv.config({ path: rootPath });
 
 if (!process.env.MODULE_NAME) {
   console.error('Environment variable "MODULE_NAME" is missing!');


### PR DESCRIPTION
Hey,

generateScopedName in rollup.config.js depends on an environment variable to  generate classnames, however rollup is not yet configured to read the env variables so we are losing the classnames in development, i have configured dotenv so rollup can load the env variables.