### PR TITLE
fix theme styles in link panel

### DIFF
--- a/packages/common/src/Components/LinkPanel.jsx
+++ b/packages/common/src/Components/LinkPanel.jsx
@@ -88,6 +88,7 @@ class LinkPanel extends Component {
   }
 
   getTextInputProps() {
+    const { styles } = this;
     const textInputClassName = classNames(styles.linkPanel_textInput, {
       [styles.linkPanel_textInput_invalid]: this.hasError(),
     });


### PR DESCRIPTION
I need to be able to use theme styles for Link Panel component's text input and I see that merged styles are not applied there. If there is no specific reason for that please let me add this.