### PR TITLE
Main example json validation improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 > - :house: [Internal]
 
 ## [Unreleased]
+### :house: Internal
+- `example`
+  - content state data validation improved
 <hr/>
 
 ## 3.5.1 (Jun 10, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `viewer`
   - [b7177a60](https://github.com/wix-incubator/rich-content/commit/b7177a60) text-utils refactoring
 - `example`
-  - content state data validation improved
+  -  [#314](https://github.com/wix-incubator/rich-content/pull/314) content state data validation improved
 <hr/>
 
 ## 3.5.1 (Jun 10, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `viewer`
   - [b7177a60](https://github.com/wix-incubator/rich-content/commit/b7177a60) text-utils refactoring
 - `example`
-  -  [#314](https://github.com/wix-incubator/rich-content/pull/314) content state data validation improved
+  - [#314](https://github.com/wix-incubator/rich-content/pull/314) content state data validation improved
 <hr/>
 
 ## 3.5.1 (Jun 10, 2019)

--- a/examples/main/src/Components/ContentStateEditor.jsx
+++ b/examples/main/src/Components/ContentStateEditor.jsx
@@ -2,7 +2,29 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import MonacoEditor from 'react-monaco-editor';
 import debounce from 'lodash/debounce';
-import contentStateSchema from 'wix-rich-content-common/dist/statics/content-state.schema.json';
+import { getContentStateSchema } from 'wix-rich-content-common';
+
+import dividerSchema from 'wix-rich-content-plugin-divider/dist/statics/data-schema.json';
+import imageSchema from 'wix-rich-content-plugin-image/dist/statics/data-schema.json';
+import videoSchema from 'wix-rich-content-plugin-video/dist/statics/data-schema.json';
+import giphySchema from 'wix-rich-content-plugin-giphy/dist/statics/data-schema.json';
+import soundCloudSchema from 'wix-rich-content-plugin-sound-cloud/dist/statics/data-schema.json';
+import fileUploadSchema from 'wix-rich-content-plugin-file-upload/dist/statics/data-schema.json';
+import mapSchema from 'wix-rich-content-plugin-map/dist/statics/data-schema.json';
+import buttonSchema from 'wix-rich-content-plugin-button/dist/statics/data-schema.json';
+import htmlSchema from 'wix-rich-content-plugin-html/dist/statics/data-schema.json';
+import linkSchema from 'wix-rich-content-plugin-link/dist/statics/data-schema.json';
+
+import { DIVIDER_TYPE } from 'wix-rich-content-plugin-divider';
+import { VIDEO_TYPE } from 'wix-rich-content-plugin-video';
+import { IMAGE_TYPE } from 'wix-rich-content-plugin-image';
+import { GIPHY_TYPE } from 'wix-rich-content-plugin-giphy';
+import { FILE_UPLOAD_TYPE } from 'wix-rich-content-plugin-file-upload';
+import { SOUND_CLOUD_TYPE } from 'wix-rich-content-plugin-sound-cloud';
+import { MAP_TYPE } from 'wix-rich-content-plugin-map';
+import { BUTTON_TYPE } from 'wix-rich-content-plugin-map';
+import { HTML_TYPE } from 'wix-rich-content-plugin-html';
+import { LINK_TYPE } from 'wix-rich-content-plugin-link';
 
 const stringifyJSON = obj => JSON.stringify(obj, null, 2);
 
@@ -39,7 +61,18 @@ class ContentStateEditor extends PureComponent {
         {
           uri: 'https://wix-rich-content/content-state-schema.json', // scema id
           fileMatch: ['*'],
-          schema: contentStateSchema,
+          schema: getContentStateSchema({
+            [DIVIDER_TYPE]: dividerSchema,
+            [IMAGE_TYPE]: imageSchema,
+            [VIDEO_TYPE]: videoSchema,
+            [GIPHY_TYPE]: giphySchema,
+            [FILE_UPLOAD_TYPE]: fileUploadSchema,
+            [SOUND_CLOUD_TYPE]: soundCloudSchema,
+            [MAP_TYPE]: mapSchema,
+            [BUTTON_TYPE]: buttonSchema,
+            [HTML_TYPE]: htmlSchema,
+            [LINK_TYPE]: linkSchema,
+          }),
         },
       ],
     });

--- a/examples/main/src/Components/ContentStateEditor.jsx
+++ b/examples/main/src/Components/ContentStateEditor.jsx
@@ -22,7 +22,7 @@ import { GIPHY_TYPE } from 'wix-rich-content-plugin-giphy';
 import { FILE_UPLOAD_TYPE } from 'wix-rich-content-plugin-file-upload';
 import { SOUND_CLOUD_TYPE } from 'wix-rich-content-plugin-sound-cloud';
 import { MAP_TYPE } from 'wix-rich-content-plugin-map';
-import { BUTTON_TYPE } from 'wix-rich-content-plugin-map';
+import { BUTTON_TYPE } from 'wix-rich-content-plugin-button';
 import { HTML_TYPE } from 'wix-rich-content-plugin-html';
 import { LINK_TYPE } from 'wix-rich-content-plugin-link';
 

--- a/packages/common/src/Utils/data-schema-validator.js
+++ b/packages/common/src/Utils/data-schema-validator.js
@@ -1,3 +1,5 @@
+import contentStateSchema from '../../statics/content-state.schema.json';
+
 export const validate = (data, schema) => {
   const Validator = require('jsonschema').Validator;
   if (process.env.NODE_ENV !== 'production') {
@@ -10,4 +12,18 @@ export const validate = (data, schema) => {
   } else {
     return true;
   }
+};
+
+export const getContentStateSchema = (pluginDataSchemas = {}) => {
+  const schema = contentStateSchema;
+  schema.definitions.entityDef.anyOf = Object.keys(pluginDataSchemas).map(pluginType => {
+    return {
+      properties: {
+        type: { const: pluginType },
+        data: pluginDataSchemas[pluginType],
+      },
+    };
+  });
+
+  return schema;
 };

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -62,7 +62,7 @@ export { simplePubsub } from './Utils/simplePubsub';
 export { getModalStyles } from './Utils/getModalStyles';
 export { mergeStyles } from './Utils/mergeStyles';
 export { default as normalizeInitialState } from './Utils/normalizeInitialState';
-export { validate } from './Utils/data-schema-validator';
+export { validate, getContentStateSchema } from './Utils/data-schema-validator';
 export { isHexColor } from './Components/ColorPicker/utils';
 
 export {

--- a/packages/common/statics/content-state.schema.json
+++ b/packages/common/statics/content-state.schema.json
@@ -1,25 +1,138 @@
 {
-  "definitions": {},
+  "definitions": {
+    "inlineStyleDef": {
+      "definitions": {},
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://wix-rich-content/inline-style.json",
+      "type": "object",
+      "title": "inline style",
+      "required": ["offset", "length", "style"],
+      "properties": {
+        "offset": {
+          "$id": "#/properties/offset",
+          "type": "integer",
+          "title": "offset",
+          "default": 0,
+          "min": 0,
+          "examples": [0]
+        },
+        "length": {
+          "$id": "#/properties/length",
+          "type": "integer",
+          "title": "length",
+          "default": 0,
+          "min": 0,
+          "examples": [4]
+        },
+        "style": {
+          "$id": "#/properties/style",
+          "type": "string",
+          "title": "style",
+          "default": "",
+          "examples": ["color4"],
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "entityRangeDef": {
+      "definitions": {},
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://wix-rich-content/entity-range.json",
+      "type": "object",
+      "title": "inline style",
+      "required": ["offset", "length", "key"],
+      "properties": {
+        "offset": {
+          "$id": "#/properties/offset",
+          "type": "integer",
+          "title": "offset",
+          "default": 0,
+          "min": 0,
+          "examples": [0]
+        },
+        "length": {
+          "$id": "#/properties/length",
+          "type": "integer",
+          "title": "length",
+          "default": 0,
+          "min": 0,
+          "examples": [4]
+        },
+        "key": {
+          "$id": "#/properties/style",
+          "type": "integer",
+          "title": "key",
+          "default": "",
+          "examples": [0]
+        }
+      }
+    },
+    "entityDef": {
+      "definitions": {},
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://wix-rich-content/entity-range.json",
+      "type": "object",
+      "title": "entity",
+      "required": ["type", "mutability", "data"],
+      "properties": {
+        "type": {
+          "$id": "#/properties/type",
+          "enum": [
+            "IMAGE",
+            "VIDEO-EMBED",
+            "LINK",
+            "wix-draft-plugin-image",
+            "wix-draft-plugin-button",
+            "wix-draft-plugin-video",
+            "wix-draft-plugin-gallery",
+            "wix-draft-plugin-link",
+            "wix-draft-plugin-html",
+            "wix-draft-plugin-sound-cloud",
+            "wix-draft-plugin-hashtag",
+            "wix-draft-plugin-divider",
+            "wix-draft-plugin-emoji",
+            "wix-draft-plugin-giphy",
+            "wix-draft-plugin-map",
+            "wix-draft-plugin-file-upload"
+          ],
+          "title": "entity type",
+          "examples": ["wix-draft-plugin-image"]
+        },
+        "mutability": {
+          "$id": "#/properties/mutability",
+          "type": "string",
+          "enum": ["MUTABLE", "IMMUTABLE"],
+          "title": "entity mutability",
+          "examples": ["IMMUTABLE"]
+        },
+        "data": {
+          "$id": "#/properties/data",
+          "type": "object",
+          "title": "entity data"
+        }
+      }
+    }
+  },
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://wix-rich-content/content-state-schema.json",
   "type": "object",
-  "title": "The Root Schema",
+  "title": "content state",
   "required": ["blocks"],
   "properties": {
     "blocks": {
       "$id": "#/properties/blocks",
       "type": "array",
-      "title": "The Blocks Schema",
+      "title": "blocks",
       "items": {
         "$id": "#/properties/blocks/items",
         "type": "object",
-        "title": "The Items Schema",
+        "title": "block",
         "required": ["key", "text", "type", "inlineStyleRanges"],
         "properties": {
           "key": {
             "$id": "#/properties/blocks/items/properties/key",
             "type": "string",
-            "title": "The Key Schema",
+            "title": "block key",
             "default": "",
             "examples": ["45qkg"],
             "pattern": "^(.*)$"
@@ -27,7 +140,7 @@
           "text": {
             "$id": "#/properties/blocks/items/properties/text",
             "type": "string",
-            "title": "The Text Schema",
+            "title": "text",
             "default": "",
             "examples": ["test"],
             "pattern": "^(.*)$"
@@ -35,33 +148,50 @@
           "type": {
             "$id": "#/properties/blocks/items/properties/type",
             "type": "string",
-            "title": "The Type Schema",
+            "title": "block type",
             "default": "",
             "examples": ["unstyled"],
-            "pattern": "^(unstyled|header-one|header-two|header-three|header-four|header-five|header-six|unordered-list-item|ordered-list-item|blockquote|atomic|code-block)$"
+            "enum": [
+              "unstyled",
+              "header-one",
+              "header-two",
+              "header-three",
+              "header-four",
+              "header-five",
+              "header-six",
+              "unordered-list-item",
+              "ordered-list-item",
+              "blockquote",
+              "atomic",
+              "code-block"
+            ]
           },
           "depth": {
             "$id": "#/properties/blocks/items/properties/depth",
             "type": "integer",
-            "title": "The Depth Schema",
+            "title": "depth",
             "default": 0,
             "examples": [0]
           },
           "inlineStyleRanges": {
             "$id": "#/properties/blocks/items/properties/inlineStyleRanges",
             "type": "array",
-            "title": "The Inlinestyleranges Schema"
+            "title": "inline style ranges",
+            "items": {
+              "$ref": "#/definitions/inlineStyleDef"
+            }
           },
           "entityRanges": {
             "$id": "#/properties/blocks/items/properties/entityRanges",
             "type": "array",
-            "title": "The Entityranges Schema",
-            "default": null
+            "title": "entity ranges",
+            "default": null,
+            "items": { "$ref": "#/definitions/entityRangeDef" }
           },
           "data": {
             "$id": "#/properties/blocks/items/properties/data",
             "type": "object",
-            "title": "The Data Schema",
+            "title": "data",
             "default": null
           }
         }
@@ -70,8 +200,12 @@
     "entityMap": {
       "$id": "#/properties/entityMap",
       "type": "object",
-      "title": "The Entitymap Schema",
-      "default": null
+      "title": "entity map",
+      "patternProperties": {
+        "[0-9]+": {
+          "$ref": "#/definitions/entityDef"
+        }
+      }
     }
   }
 }

--- a/packages/plugin-button/statics/data-schema.json
+++ b/packages/plugin-button/statics/data-schema.json
@@ -1,5 +1,6 @@
 {
-  "$id": "http://path/to/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/button-content-data-schema.json",
   "type": "object",
   "properties": {
     "button": {
@@ -101,13 +102,6 @@
           "title": "alignment",
           "default": "center",
           "examples": ["center", "right", "left"]
-        },
-        "key": {
-          "$id": "/properties/config/properties/key",
-          "type": "string",
-          "title": "The Key Schema ",
-          "default": "",
-          "examples": ["78mi0"]
         }
       }
     }

--- a/packages/plugin-divider/statics/data-schema.json
+++ b/packages/plugin-divider/statics/data-schema.json
@@ -1,45 +1,32 @@
 {
-  "$id": "http://path/to/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/divider-content-data-schema.json",
   "type": "object",
   "properties": {
     "type": {
-      "$id": "/properties/type",
-      "type": "string",
-      "title": "Divider Type",
-      "default": "single",
+      "enum": ["double", "single", "dashed"],
+      "title": "divider type",
       "examples": ["double", "single", "dashed"]
     },
     "config": {
-      "$id": "/properties/config",
       "type": "object",
+      "title": "configuration",
       "properties": {
         "size": {
           "$id": "/properties/config/properties/size",
-          "type": "string",
-          "title": "Size",
-          "default": "large",
+          "enum": ["medium", "small", "large"],
+          "title": "size",
           "examples": ["medium", "small", "large"]
         },
         "alignment": {
-          "$id": "/properties/config/properties/alignment",
-          "type": "string",
-          "title": "The Alignment Schema ",
-          "default": "center",
+          "enum": ["left", "right", "center"],
+          "title": "alignment",
           "examples": ["left", "right", "center"]
         },
         "textWrap": {
-          "$id": "/properties/config/properties/textWrap",
           "type": "string",
-          "title": "The Textwrap Schema ",
-          "default": "nowrap",
+          "title": "text wrap style",
           "examples": ["nowrap"]
-        },
-        "key": {
-          "$id": "/properties/config/properties/key",
-          "type": "string",
-          "title": "The Key Schema ",
-          "default": "",
-          "examples": ["7mib0"]
         }
       }
     }

--- a/packages/plugin-file-upload/statics/data-schema.json
+++ b/packages/plugin-file-upload/statics/data-schema.json
@@ -1,5 +1,6 @@
 {
-  "$id": "http://path/to/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/file-upload-content-data-schema.json",
   "type": "object",
   "properties": {
     "config": {

--- a/packages/plugin-giphy/statics/data-schema.json
+++ b/packages/plugin-giphy/statics/data-schema.json
@@ -1,5 +1,6 @@
 {
-  "$id": "http://path/to/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/giphy-content-data-schema.json",
   "type": "object",
   "properties": {
     "gif": {
@@ -54,13 +55,6 @@
           "title": "The Alignment Schema ",
           "default": "center",
           "examples": ["left", "right", "center"]
-        },
-        "key": {
-          "$id": "/properties/config/properties/key",
-          "type": "string",
-          "title": "The Key Schema ",
-          "default": "",
-          "examples": ["7mib0"]
         }
       }
     }

--- a/packages/plugin-html/statics/data-schema.json
+++ b/packages/plugin-html/statics/data-schema.json
@@ -1,5 +1,6 @@
 {
-  "$id": "http://path/to/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/html-content-data-schema.json",
   "type": "object",
   "properties": {
     "src": {

--- a/packages/plugin-image/statics/data-schema.json
+++ b/packages/plugin-image/statics/data-schema.json
@@ -1,72 +1,65 @@
 {
-  "$id": "http://path/to/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/image-content-data-schema.json",
   "type": "object",
+  "required": ["src"],
   "properties": {
     "config": {
       "$id": "/properties/config",
       "type": "object",
+      "title": "configuration",
       "properties": {
         "size": {
           "$id": "/properties/config/properties/size",
-          "type": "string",
-          "title": "Size",
-          "default": "large",
-          "examples": ["medium", "small", "large"]
+          "enum": ["content", "small", "original", "fullWidth"],
+          "title": "size",
+          "examples": ["content", "small", "original", "fullWidth"]
         },
         "alignment": {
           "$id": "/properties/config/properties/alignment",
-          "type": "string",
-          "title": "The Alignment Schema ",
-          "default": "center",
+          "enum": ["left", "right", "center"],
+          "title": "alignment",
           "examples": ["left", "right", "center"]
         },
         "showTitle": {
           "$id": "/properties/config/properties/showTitle",
           "type": "boolean",
-          "title": "showTitle flag",
+          "title": "show title",
           "default": false,
           "examples": [true]
         },
         "showDescription": {
           "$id": "/properties/config/properties/showDescription",
           "type": "boolean",
-          "title": "showDescription flag",
+          "title": "show description",
           "default": false,
           "examples": [true]
         },
         "link": {
           "$id": "/properties/config/properties/link",
           "type": ["object", "null"],
+          "required": ["url"],
           "properties": {
             "url": {
               "$id": "/properties/config/properties/link/properties/url",
               "type": "string",
               "title": "URL",
-              "default": "",
               "examples": ["wix.com"]
             },
             "target": {
               "$id": "/properties/config/properties/link/properties/target",
-              "type": "string",
-              "title": "Link Target",
-              "default": "",
+              "enum": ["_blank", "_self", "_top"],
+              "title": "link target",
               "examples": ["_blank"]
             },
             "rel": {
               "$id": "/properties/config/properties/link/properties/rel",
               "type": "string",
-              "title": "Link rel",
+              "title": "link rel",
               "default": "noopener",
               "examples": ["nofollow", "noreferrer"]
             }
           }
-        },
-        "key": {
-          "$id": "/properties/config/properties/key",
-          "type": "string",
-          "title": "Entity Block Key",
-          "default": "",
-          "examples": ["7tfhb"]
         }
       }
     },
@@ -77,35 +70,32 @@
         "id": {
           "$id": "/properties/src/properties/id",
           "type": "string",
-          "title": "ID",
-          "default": "",
+          "title": "id",
           "examples": ["8310d26374ed948918b9914ea076e411"]
         },
         "original_file_name": {
           "$id": "/properties/src/properties/original_file_name",
           "type": "string",
           "title": "The original file name",
-          "default": "",
           "examples": ["8bb438_b5957febd0ed45d3be9a0e91669c65b4.jpg"]
         },
         "file_name": {
           "$id": "/properties/src/properties/file_name",
           "type": "string",
           "title": "The file name",
-          "default": "",
           "examples": ["8bb438_b5957febd0ed45d3be9a0e91669c65b4.jpg"]
         },
         "width": {
           "$id": "/properties/src/properties/width",
           "type": "integer",
-          "title": "Image Width",
+          "title": "image width",
           "default": 0,
           "examples": [1621]
         },
         "height": {
           "$id": "/properties/src/properties/height",
           "type": "integer",
-          "title": "Image Height",
+          "title": "image height",
           "default": 0,
           "examples": [1081]
         }
@@ -118,15 +108,13 @@
         "alt": {
           "$id": "/properties/metadata/properties/alt",
           "type": "string",
-          "title": "Alt text",
-          "default": "",
+          "title": "alt text",
           "examples": ["alt"]
         },
         "caption": {
           "$id": "/properties/metadata/properties/caption",
           "type": "string",
           "title": "Image caption",
-          "default": "",
           "examples": ["Wanted dead or alive"]
         }
       }

--- a/packages/plugin-link/statics/data-schema.json
+++ b/packages/plugin-link/statics/data-schema.json
@@ -1,8 +1,8 @@
 {
-  "$id": "http://path/to/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/link-content-data-schema.json",
   "type": "object",
   "definitions": {},
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "href": {
       "$id": "/properties/href",

--- a/packages/plugin-map/statics/data-schema.json
+++ b/packages/plugin-map/statics/data-schema.json
@@ -1,5 +1,6 @@
 {
-  "$id": "http://path/to/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/map-content-data-schema.json",
   "type": "object",
   "properties": {
     "zoom": {
@@ -32,15 +33,6 @@
             "left",
             "right",
             "center"
-          ]
-        },
-        "key": {
-          "$id": "/properties/config/properties/key",
-          "type": "string",
-          "title": "The Key Schema ",
-          "default": "",
-          "examples": [
-            "7mib0"
           ]
         }
       }

--- a/packages/plugin-sound-cloud/statics/data-schema.json
+++ b/packages/plugin-sound-cloud/statics/data-schema.json
@@ -1,5 +1,6 @@
 {
-  "$id": "http://path/to/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/sound-cloud-content-data-schema.json",
   "type": "object",
   "properties": {
     "src": {
@@ -33,13 +34,6 @@
           "title": "The Textwrap Schema ",
           "default": "nowrap",
           "examples": ["nowrap"]
-        },
-        "key": {
-          "$id": "/properties/config/properties/key",
-          "type": "string",
-          "title": "The Key Schema ",
-          "default": "",
-          "examples": ["7mib0"]
         }
       }
     }

--- a/packages/plugin-video/statics/data-schema.json
+++ b/packages/plugin-video/statics/data-schema.json
@@ -1,5 +1,6 @@
 {
-  "$id": "http://path/to/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wix-rich-content/video-content-data-schema.json",
   "type": "object",
   "properties": {
     "src": {
@@ -8,7 +9,6 @@
           "$id": "/properties/src",
           "type": "string",
           "title": "Video Source URL",
-          "default": "",
           "examples": ["https://www.youtube.com/watch?v=eqZVIiD6wSg"]
         },
         {
@@ -19,7 +19,6 @@
               "$id": "/properties/src/pathname",
               "type": "string",
               "title": "Video Source Pathname",
-              "default": "",
               "examples": ["video-sample/jellyfish-25-mbps-hd-hevc.mp4"]
             },
             "thumbnail": {
@@ -30,22 +29,19 @@
                   "$id": "/properties/src/thumbnail/pathname",
                   "type": "string",
                   "title": "Video Thumbnail Pathname",
-                  "default": "",
                   "examples": ["media/441c23_84f5c058e5e4479ab9e626cd5560a21bf002.jpg"]
                 },
                 "height": {
                   "$id": "/properties/src/thumbnail/height",
-                  "type": "number",
+                  "type": "integer",
                   "title": "Video Thumbnail Height",
-                  "default": "",
-                  "examples": ["1080"]
+                  "examples": [1080]
                 },
                 "width": {
                   "$id": "/properties/src/thumbnail/width",
-                  "type": "number",
+                  "type": "integer",
                   "title": "Video Thumbnail Width",
-                  "default": "",
-                  "examples": ["1920"]
+                  "examples": [1920]
                 }
               }
             }
@@ -55,41 +51,35 @@
     },
     "isCustomVideo": {
       "$id": "/properties/isCustomVideo",
-      "type": "bool",
+      "type": "boolean",
       "title": "Is Custom Video",
-      "default": "false"
+      "default": false
     },
     "config": {
       "$id": "/properties/config",
       "type": "object",
+      "title": "configuration",
       "properties": {
         "size": {
           "$id": "/properties/config/properties/size",
-          "type": "string",
+          "enum": ["content", "small", "fullWidth"],
           "title": "Size",
           "default": "large",
-          "examples": ["medium", "small", "large"]
+          "examples": ["content", "small", "fullWidth"]
         },
         "alignment": {
           "$id": "/properties/config/properties/alignment",
-          "type": "string",
-          "title": "The Alignment Schema ",
+          "enum": ["left", "right", "center"],
+          "title": "Alignment",
           "default": "center",
           "examples": ["left", "right", "center"]
         },
         "textWrap": {
           "$id": "/properties/config/properties/textWrap",
           "type": "string",
-          "title": "The Textwrap Schema ",
+          "title": "Text Wrap",
           "default": "nowrap",
           "examples": ["nowrap"]
-        },
-        "key": {
-          "$id": "/properties/config/properties/key",
-          "type": "string",
-          "title": "The Key Schema ",
-          "default": "",
-          "examples": ["7mib0"]
         }
       }
     }


### PR DESCRIPTION
### :house: Internal
- `plugins`
  - some validation schemas refined
- `example/main`
  - content state data validation now processes ranges and entity data, according  to the entity type
