### PR TITLE
[file upload plugin] allow for async file url resolution

### DIFF
--- a/packages/plugin-file-upload/src/file-upload-viewer.jsx
+++ b/packages/plugin-file-upload/src/file-upload-viewer.jsx
@@ -15,6 +15,7 @@ class FileUploadViewer extends PureComponent {
     super(props);
     const { componentData } = props;
     validate(componentData, schema);
+    this.fileDownloadIframeId = `${Date.now()}`;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -88,7 +89,7 @@ class FileUploadViewer extends PureComponent {
 
     const resolveFileUrl = () => {
       settings.resolveFileUrl(componentData).then(resolveFileUrl => {
-        document.getElementById('fileDownloadIframe').src = resolveFileUrl;
+        document.getElementById(this.fileDownloadIframeId).src = resolveFileUrl;
         this.setState({ resolveFileUrl });
       });
     };
@@ -113,7 +114,7 @@ class FileUploadViewer extends PureComponent {
       return null;
     }
 
-    return <iframe id="fileDownloadIframe" style={{ display: 'none' }} title="file" />;
+    return <iframe id={this.fileDownloadIframeId} style={{ display: 'none' }} title="file" />;
   }
 
   render() {

--- a/packages/plugin-file-upload/src/file-upload-viewer.jsx
+++ b/packages/plugin-file-upload/src/file-upload-viewer.jsx
@@ -7,6 +7,10 @@ import schema from '../statics/data-schema.json';
 import styles from '../statics/styles/file-upload-viewer.scss';
 
 class FileUploadViewer extends PureComponent {
+  state = {
+    resolvedFileUrl: null,
+  };
+
   constructor(props) {
     super(props);
     const { componentData } = props;
@@ -44,18 +48,9 @@ class FileUploadViewer extends PureComponent {
     );
   }
 
-  renderViewer() {
-    const {
-      error,
-      componentData: { name, type, url },
-    } = this.props;
-
-    if (error) {
-      return null;
-    }
-
+  renderViewerBody({ type, name }) {
     return (
-      <a href={url} className={this.styles.file_upload_link}>
+      <React.Fragment>
         <div className={this.styles.file_upload_icon_container}>
           <DocumentIcon className={this.styles.file_upload_icon} />
           <span className={this.styles.file_upload_type}>{type}</span>
@@ -63,18 +58,77 @@ class FileUploadViewer extends PureComponent {
         <div className={this.styles.file_upload_name_container}>
           <span className={this.styles.file_upload_name}>{name}</span>
         </div>
+      </React.Fragment>
+    );
+  }
+
+  renderViewer(fileUrl) {
+    const {
+      error,
+      componentData: { name, type },
+    } = this.props;
+
+    if (error) {
+      return null;
+    }
+
+    return (
+      <a href={fileUrl} className={this.styles.file_upload_link}>
+        {this.renderViewerBody({ name, type })}
       </a>
     );
   }
 
+  renderFileUrlResolver() {
+    const { error, componentData, settings } = this.props;
+
+    if (error) {
+      return null;
+    }
+
+    const resolveFileUrl = () => {
+      settings.resolveFileUrl(componentData).then(resolveFileUrl => {
+        document.getElementById('fileDownloadIframe').src = resolveFileUrl;
+        this.setState({ resolveFileUrl });
+      });
+    };
+
+    return (
+      <div
+        onClick={resolveFileUrl}
+        onKeyUp={resolveFileUrl}
+        role="button"
+        tabIndex={0}
+        className={this.styles.file_upload_link}
+      >
+        {this.renderViewerBody({ name: componentData.name, type: componentData.type })}
+      </div>
+    );
+  }
+
+  renderAutoDownloadIframe() {
+    const withFileUrlResolver = this.props.settings.resolveFileUrl;
+
+    if (!withFileUrlResolver) {
+      return null;
+    }
+
+    return <iframe id="fileDownloadIframe" style={{ display: 'none' }} title="file" />;
+  }
+
   render() {
+    const { componentData } = this.props;
     const { theme } = this.context;
     this.styles = this.styles || mergeStyles({ styles, theme });
+
+    const fileUrl = componentData.url || this.state.resolveFileUrl;
+
     return (
       <div className={this.styles.file_upload_container}>
-        {this.renderViewer()}
+        {fileUrl ? this.renderViewer(fileUrl) : this.renderFileUrlResolver()}
         {this.renderLoader()}
         {this.renderError()}
+        {this.renderAutoDownloadIframe()}
       </div>
     );
   }
@@ -84,10 +138,12 @@ FileUploadViewer.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   componentData: PropTypes.object.isRequired,
   error: PropTypes.string,
+  settings: PropTypes.object.isRequired,
 };
 
 FileUploadViewer.defaultProps = {
   isLoading: false,
+  settings: {},
 };
 
 FileUploadViewer.contextType = Context.type;

--- a/packages/plugin-file-upload/src/file-upload-viewer.jsx
+++ b/packages/plugin-file-upload/src/file-upload-viewer.jsx
@@ -88,6 +88,9 @@ class FileUploadViewer extends PureComponent {
     }
 
     const resolveFileUrl = () => {
+      if (!settings.resolveFileUrl) {
+        return;
+      }
       settings.resolveFileUrl(componentData).then(resolveFileUrl => {
         document.getElementById(this.fileDownloadIframeId).src = resolveFileUrl;
         this.setState({ resolveFileUrl });
@@ -139,7 +142,7 @@ FileUploadViewer.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   componentData: PropTypes.object.isRequired,
   error: PropTypes.string,
-  settings: PropTypes.object.isRequired,
+  settings: PropTypes.object,
 };
 
 FileUploadViewer.defaultProps = {


### PR DESCRIPTION
We want to be able to resolve file url on demand, this way we can handle private file downloading.

On file upload we will not save file url to content state, but some other metadata which will be used by url resolver to resolve it on demand (while also checking if user has necessary permissions)