### PR TITLE
color picker layout render API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@
 > - :house: [Internal]
 
 ## [Unreleased]
+### :rocket: New Feature
+- `common`
+  - `color-picker` layout now rendered by a component consumer via the `children` prop
 ### :bug: Bug Fix
 - `editor`
   - [45968d56](https://github.com/wix-incubator/rich-content/commit/45968d56) static toolbar displays tooltips
 ### :house: Internal
+- `text-color`
+  - `color-picker` layout rendered by a `text-color-panel`
 - `general`
   - [e791fc1b](https://github.com/wix-incubator/rich-content/commit/e791fc1b) isMobile prop passed to internal plugin modals
 <hr/>

--- a/packages/common/src/Components/ColorPicker/ColorPicker.jsx
+++ b/packages/common/src/Components/ColorPicker/ColorPicker.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { mergeStyles } from '../../Utils/mergeStyles';
-import CustomColorPickerDialog from './CustomColorPickerDialog';
+import DefaultColorPicker from './DefaultColorPicker';
 import AddColorIcon from '../../Icons/AddColorIcon';
 import styles from '../../../statics/styles/color-picker.scss';
 
@@ -84,7 +84,7 @@ class ColorPicker extends PureComponent {
     return <hr className={styles.colorPicker_separator} />;
   }
 
-  renderAddColorButton() {
+  renderAddColorButton = () => {
     const { styles } = this;
     return (
       <div key={`add_color_button_${this.id}`} className={styles.colorPicker_add_color_button}>
@@ -102,35 +102,32 @@ class ColorPicker extends PureComponent {
         </label>
       </div>
     );
-  }
+  };
+
+  renderPalette = () => this.renderColorButtons(this.props.palette, this.props.schemeAttributes);
+  renderUserColors = () => this.renderColorButtons(this.props.userColors);
 
   render() {
-    const { styles } = this;
-    const { t, isMobile, theme } = this.props;
+    const { styles, renderPalette, renderUserColors, renderAddColorButton } = this;
+    const { t, isMobile, theme, children } = this.props;
     return (
       <div className={styles.colorPicker}>
-        {this.state.isCustomColorPickerOpened ? (
-          this.props.onCustomPickerToggle({
-            color: this.state.color,
-            onCustomColorPicked: this.onCustomColorPicked,
-            onCustomColorCancel: this.onCustomColorCancel,
-            onCustomColorUpdate: this.onCustomColorUpdate,
-            t,
-            isMobile,
-            theme,
-          })
-        ) : (
-          <div className={styles.colorPicker_palette}>
-            <div className={styles.colorPicker_buttons_container}>
-              {this.renderColorButtons(this.props.palette, this.props.schemeAttributes)}
-            </div>
-            {this.renderSeparator()}
-            <div className={styles.colorPicker_buttons_container}>
-              {this.renderColorButtons(this.props.userColors)}
-              {this.renderAddColorButton()}
-            </div>
-          </div>
-        )}
+        {this.state.isCustomColorPickerOpened
+          ? this.props.onCustomPickerToggle({
+              color: this.state.color,
+              onCustomColorPicked: this.onCustomColorPicked,
+              onCustomColorCancel: this.onCustomColorCancel,
+              onCustomColorUpdate: this.onCustomColorUpdate,
+              t,
+              isMobile,
+              theme,
+            })
+          : children({
+              renderPalette,
+              renderUserColors,
+              renderAddColorButton,
+              mergedStyles: styles,
+            })}
       </div>
     );
   }
@@ -149,32 +146,7 @@ ColorPicker.propTypes = {
   onCustomPickerToggle: PropTypes.func,
   onCustomColorPicked: PropTypes.func,
   isMobile: PropTypes.bool,
-};
-
-const DefaultColorPicker = ({
-  color,
-  onCustomColorPicked,
-  onCustomColorCancel,
-  onCustomColorUpdate,
-  ...props
-}) => (
-  <CustomColorPickerDialog
-    color={color}
-    onChange={onCustomColorPicked}
-    onUpdate={onCustomColorUpdate}
-    onCancel={onCustomColorCancel}
-    {...props}
-  />
-);
-
-DefaultColorPicker.propTypes = {
-  color: PropTypes.string.isRequired,
-  onCustomColorPicked: PropTypes.func,
-  onCustomColorCancel: PropTypes.func,
-  onCustomColorUpdate: PropTypes.func,
-  t: PropTypes.func,
-  isMobile: PropTypes.bool,
-  theme: PropTypes.object.isRequired,
+  children: PropTypes.func.isRequired,
 };
 
 ColorPicker.defaultProps = {

--- a/packages/common/src/Components/ColorPicker/DefaultColorPicker.js
+++ b/packages/common/src/Components/ColorPicker/DefaultColorPicker.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CustomColorPickerDialog from './CustomColorPickerDialog';
+
+const DefaultColorPicker = ({
+  color,
+  onCustomColorPicked,
+  onCustomColorCancel,
+  onCustomColorUpdate,
+  ...props
+}) => (
+  <CustomColorPickerDialog
+    color={color}
+    onChange={onCustomColorPicked}
+    onUpdate={onCustomColorUpdate}
+    onCancel={onCustomColorCancel}
+    {...props}
+  />
+);
+
+DefaultColorPicker.propTypes = {
+  color: PropTypes.string.isRequired,
+  onCustomColorPicked: PropTypes.func,
+  onCustomColorCancel: PropTypes.func,
+  onCustomColorUpdate: PropTypes.func,
+  t: PropTypes.func,
+  isMobile: PropTypes.bool,
+  theme: PropTypes.object.isRequired,
+};
+
+export default DefaultColorPicker;

--- a/packages/plugin-text-color/src/toolbar/TextColorPanel.jsx
+++ b/packages/plugin-text-color/src/toolbar/TextColorPanel.jsx
@@ -92,7 +92,18 @@ export default class TextColorPanel extends Component {
         t={t}
         setKeepToolbarOpen={setKeepToolbarOpen}
         isMobile={isMobile}
-      />
+      >
+        {({ renderPalette, renderUserColors, renderAddColorButton, mergedStyles }) => (
+          <div className={mergedStyles.colorPicker_palette}>
+            <div className={mergedStyles.colorPicker_buttons_container}>{renderPalette()}</div>
+            <hr className={mergedStyles.colorPicker_separator} />
+            <div className={mergedStyles.colorPicker_buttons_container}>
+              {renderUserColors()}
+              {renderAddColorButton()}
+            </div>
+          </div>
+        )}
+      </ColorPicker>
     );
   }
 }


### PR DESCRIPTION
### :rocket: New Feature
- `common`
  - `color-picker` layout now rendered by a component consumer via the `children` prop
### :house: Internal
- `text-color`
  - `color-picker` layout rendered by a `text-color-panel`