### PR TITLE
Add rtlcss ignore directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## [Unreleased]
 - `file-upload`
   - [#345](https://github.com/wix-incubator/rich-content/pull/345) handle empty file name
+- `editor`
+  - [#349](https://github.com/wix-incubator/rich-content/pull/349) Add rtlcss ignore directives
 <hr/>
 
 ## 4.0.10 (Jul 29, 2019)

--- a/packages/common/statics/styles/global.scss
+++ b/packages/common/statics/styles/global.scss
@@ -75,14 +75,18 @@
 }
 
 .alignLeft {
+  /*!rtl:ignore*/
   float: left;
   z-index: 1;
 
   &:not(.textWrapNowrap) {
+    /*!rtl:begin:ignore*/
     margin-right: $innerSpacing;
     margin-left: 0;
+    /*!rtl:end:ignore*/
 
     @include phone {
+      /*!rtl:ignore*/
       margin-right: 0;
     }
   }
@@ -98,14 +102,18 @@
 }
 
 .alignRight {
+  /*!rtl:ignore*/
   float: right;
   z-index: 1;
 
   &:not(.textWrapNowrap) {
+    /*!rtl:begin:ignore*/
     margin-left: $innerSpacing;
     margin-right: 0;
+    /*!rtl:end:ignore*/
 
     @include phone {
+      /*!rtl:ignore*/
       margin-left: 0;
     }
   }

--- a/packages/editor/statics/styles/draft.scss
+++ b/packages/editor/statics/styles/draft.scss
@@ -15,11 +15,15 @@
       position: relative;
     }
     .DraftEditor-alignLeft .public-DraftStyleDefault-block {
+      /*!rtl:begin:ignore*/
       text-align: left;
+      /*!rtl:end:ignore*/
     }
     .DraftEditor-alignLeft .public-DraftEditorPlaceholder-root {
+      /*!rtl:begin:ignore*/
       left: 0;
       text-align: left;
+      /*!rtl:end:ignore*/
     }
     .DraftEditor-alignCenter .public-DraftStyleDefault-block {
       text-align: center;
@@ -30,29 +34,41 @@
       width: 100%;
     }
     .DraftEditor-alignRight .public-DraftStyleDefault-block {
+      /*!rtl:begin:ignore*/
       text-align: right;
+      /*!rtl:end:ignore*/
     }
     .DraftEditor-alignRight .public-DraftEditorPlaceholder-root {
+      /*!rtl:begin:ignore*/
       right: 0;
       text-align: right;
+      /*!rtl:end:ignore*/
     }
     .public-DraftStyleDefault-block {
       position: relative;
       white-space: pre-wrap;
     }
     .public-DraftStyleDefault-ltr {
+      /*!rtl:begin:ignore*/
       direction: ltr;
       text-align: left;
+      /*!rtl:end:ignore*/
     }
     .public-DraftStyleDefault-rtl {
+      /*!rtl:begin:ignore*/
       direction: rtl;
       text-align: right;
+      /*!rtl:end:ignore*/
     }
     .public-DraftStyleDefault-listLTR {
+      /*!rtl:begin:ignore*/
       direction: ltr;
+      /*!rtl:end:ignore*/
     }
     .public-DraftStyleDefault-listRTL {
+      /*!rtl:begin:ignore*/
       direction: rtl;
+      /*!rtl:end:ignore*/
     }
     .public-DraftStyleDefault-ol,
     .public-DraftStyleDefault-ul {

--- a/packages/editor/statics/styles/rich-content-editor.scss
+++ b/packages/editor/statics/styles/rich-content-editor.scss
@@ -91,6 +91,7 @@
 
 .left {
   &>* {
+    /*!rtl:ignore*/
     text-align: left !important;
   }
 }
@@ -103,6 +104,7 @@
 
 .right {
   &>* {
+    /*!rtl:ignore*/
     text-align: right !important;
   }
 }

--- a/packages/viewer/statics/rich-content-viewer.scss
+++ b/packages/viewer/statics/rich-content-viewer.scss
@@ -102,9 +102,11 @@
 }
 
 .left {
+  /*!rtl:ignore*/
   text-align: left !important;
 
   & > * {
+    /*!rtl:ignore*/
     text-align: left !important;
   }
 }
@@ -118,9 +120,11 @@
 }
 
 .right {
+  /*!rtl:ignore*/
   text-align: right !important;
 
   & > * {
+    /*!rtl:ignore*/
     text-align: right !important;
   }
 }
@@ -225,5 +229,6 @@
 }
 
 .rtl {
+  /*!rtl:ignore*/
   direction: rtl;
 }


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
Yoshi automatically runs all CSS through rtlcss and adjusts it for RTL layout. Since you guys already did a great job of supporting RTL in the RCE, we do not need to modify this CSS, so I added ignore directives.