### PR TITLE
Fix Google 'Touch to Search' trigger when clicking on mention 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ## [Unreleased]
 ### :bug: Bug Fix
 - `editor`
+  - [#354](https://github.com/wix-incubator/rich-content/pull/354) Fix Google 'Touch to Search' trigger when clicking on mention
+### :bug: Bug Fix
+- `editor`
   - [#353](https://github.com/wix-incubator/rich-content/pull/353) fix line spacing in lists
 ### :rocket: New Feature
 - `viewer`
@@ -53,7 +56,7 @@
 ## 4.0.8 (Jul 24, 2019)
 ### :bug: Bug Fix
 - `html`
-  - [#338](https://github.com/wix-incubator/rich-content/pull/338) fix performance.now() breaks ssr 
+  - [#338](https://github.com/wix-incubator/rich-content/pull/338) fix performance.now() breaks ssr
 - `file-upload`
   - [#340](https://github.com/wix-incubator/rich-content/pull/340) unique ids for icons
 <hr/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@
 ## [Unreleased]
 ### :bug: Bug Fix
 - `editor`
-  - [#354](https://github.com/wix-incubator/rich-content/pull/354) Fix Google 'Touch to Search' trigger when clicking on mention
-### :bug: Bug Fix
-- `editor`
   - [#353](https://github.com/wix-incubator/rich-content/pull/353) fix line spacing in lists
+- `mentions`
+  - [#354](https://github.com/wix-incubator/rich-content/pull/354) Fix Google 'Touch to Search' trigger when clicking on mention
 ### :rocket: New Feature
 - `viewer`
   - [#351](https://github.com/wix-incubator/rich-content/pull/351) `disable` prop allows pausing media

--- a/packages/plugin-mentions/src/MentionComponent.jsx
+++ b/packages/plugin-mentions/src/MentionComponent.jsx
@@ -14,6 +14,7 @@ const MentionComponent = ({ children, mention, settings, contextType }) => {
           <a
             href={getMentionLink(mention)}
             rel="noopener noreferrer"
+            role="link"
             className={mergedStyles.mention}
             onClick={() => onMentionClick(mention)}
           >

--- a/packages/plugin-mentions/src/MentionComponent.jsx
+++ b/packages/plugin-mentions/src/MentionComponent.jsx
@@ -14,7 +14,7 @@ const MentionComponent = ({ children, mention, settings, contextType }) => {
           <a
             href={getMentionLink(mention)}
             rel="noopener noreferrer"
-            role="link"
+            tabindex="0"
             className={mergedStyles.mention}
             onClick={() => onMentionClick(mention)}
           >

--- a/packages/plugin-mentions/src/MentionComponent.jsx
+++ b/packages/plugin-mentions/src/MentionComponent.jsx
@@ -14,7 +14,7 @@ const MentionComponent = ({ children, mention, settings, contextType }) => {
           <a
             href={getMentionLink(mention)}
             rel="noopener noreferrer"
-            tabindex="0"
+            tabIndex="0"
             className={mergedStyles.mention}
             onClick={() => onMentionClick(mention)}
           >


### PR DESCRIPTION
There is a bug on Android, when clicking on mention it selects the text of the mention and triggers Google 'Touch to Search' functionality and only when navigates to mentioned person profile. Happens when href is empty - added tabindex="0" so element is always focusable and doesn't trigger the 'Touch to Search'

https://developers.google.com/web/updates/2015/10/tap-to-search   