### PR TITLE
Uses unique file input id (to work with multiple instances of RCE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
   - `video`
     - [#443](https://github.com/wix-incubator/rich-content/pull/443) async url resolving support
     - [#444](https://github.com/wix-incubator/rich-content/pull/444) file upload support
-    - [#449](https://github.com/wix-incubator/rich-content/pull/444) force video mime type for uploads
+    - [#449](https://github.com/wix-incubator/rich-content/pull/449) force video mime type for uploads
+    - [#451](https://github.com/wix-incubator/rich-content/pull/451) uses unique file input id
   ### :bug: Bug Fix
   - `divider`
     - [#438](https://github.com/wix-incubator/rich-content/pull/438) container alignment

--- a/packages/plugin-video/web/src/toolbar/videoSelectionInputModal.jsx
+++ b/packages/plugin-video/web/src/toolbar/videoSelectionInputModal.jsx
@@ -15,6 +15,7 @@ export default class VideoSelectionInputModal extends Component {
       isCustomVideo: false,
       errorMsg: '',
     };
+    this.id = `VideoUploadModal_FileInput_${Math.floor(Math.random() * 9999)}`;
   }
 
   onUrlChange = e => {
@@ -118,7 +119,7 @@ export default class VideoSelectionInputModal extends Component {
         </div>
         <div className={styles.video_modal_upload_video}>
           <input
-            id="VideoUploadModal_FileInput"
+            id={this.id}
             type="file"
             accept="video/*"
             className={styles.fileInput}
@@ -126,7 +127,7 @@ export default class VideoSelectionInputModal extends Component {
             onClick={handleClick}
           />
           <label
-            htmlFor="VideoUploadModal_FileInput"
+            htmlFor={this.id}
             className={styles.fileInputLabel}
             role="button"
             data-hook="videoUploadModalCustomVideo"


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
