### PR TITLE
Fix/on atomic block focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   </summary>
 
   ### :bug: Bug Fix
+  - `editor-common`
+    - getBlockInfo util arguments fixed
   - `link`
     - [#546](https://github.com/wix-incubator/rich-content/pull/546) saves the last data and the initial state of the checkboxes("Open in a new tab", "Add a nofollow tag") is according to the defaults (anchorTarget, relValue)
 </details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
   ### :bug: Bug Fix
   - `editor-common`
-    - getBlockInfo util arguments fixed
+    - [#558](https://github.com/wix-incubator/rich-content/pull/558) getBlockInfo util arguments fixed
   - `link`
     - [#546](https://github.com/wix-incubator/rich-content/pull/546) saves the last data and the initial state of the checkboxes("Open in a new tab", "Add a nofollow tag") is according to the defaults (anchorTarget, relValue)
 </details>

--- a/packages/editor-common/web/src/Utils/draftUtils.js
+++ b/packages/editor-common/web/src/Utils/draftUtils.js
@@ -344,8 +344,8 @@ export function getFocusedBlockKey(editorState) {
   return selection.isCollapsed() && selection.getAnchorKey();
 }
 
-export function getBlockInfo(blockKey) {
-  const contentState = this.getEditorState().getCurrentContent();
+export function getBlockInfo(editorState, blockKey) {
+  const contentState = editorState.getCurrentContent();
   const block = contentState.getBlockForKey(blockKey);
   const type = block.type;
   const entityKey = block.getEntityAt(0);

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
@@ -70,7 +70,7 @@ class RichContentEditor extends Component {
     const { onAtomicBlockFocus } = this.props;
     if (onAtomicBlockFocus) {
       if (blockKey) {
-        const { type, entityData: data } = getBlockInfo(blockKey);
+        const { type, entityData: data } = getBlockInfo(this.getEditorState(), blockKey);
         onAtomicBlockFocus({ blockKey, type, data });
       }
       onAtomicBlockFocus({});


### PR DESCRIPTION
### :bug: Bug Fix
  - `editor-common`
    - getBlockInfo util arguments fixed