### PR TITLE
Fix/get block info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
     Click to see more.
   </summary>
 
+### :bug: Bug Fix
+  - `editor-common`
+    - getBlockInfo returns entity type rather block type
   - `link`
     - [#546](https://github.com/wix-incubator/rich-content/pull/546) saves the last data and the initial state of the checkboxes("Open in a new tab", "Add a nofollow tag") is according to the defaults (anchorTarget, relValue)
 </details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@
     Click to see more.
   </summary>
 
-### :bug: Bug Fix
+  ### :bug: Bug Fix
   - `editor-common`
     - getBlockInfo returns entity type rather block type
   - `link`
     - [#546](https://github.com/wix-incubator/rich-content/pull/546) saves the last data and the initial state of the checkboxes("Open in a new tab", "Add a nofollow tag") is according to the defaults (anchorTarget, relValue)
+
 </details>
 <hr/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
   ### :bug: Bug Fix
   - `editor-common`
-    - getBlockInfo returns entity type rather block type
+    - [#560](https://github.com/wix-incubator/rich-content/pull/560) getBlockInfo returns entity type rather block type
   - `link`
     - [#546](https://github.com/wix-incubator/rich-content/pull/546) saves the last data and the initial state of the checkboxes("Open in a new tab", "Add a nofollow tag") is according to the defaults (anchorTarget, relValue)
 

--- a/packages/editor-common/web/src/Utils/draftUtils.js
+++ b/packages/editor-common/web/src/Utils/draftUtils.js
@@ -347,10 +347,12 @@ export function getFocusedBlockKey(editorState) {
 export function getBlockInfo(editorState, blockKey) {
   const contentState = editorState.getCurrentContent();
   const block = contentState.getBlockForKey(blockKey);
-  const type = block.type;
   const entityKey = block.getEntityAt(0);
-  const entityData = entityKey && contentState.getEntity(entityKey)?.data;
-  return { type, entityData };
+  const entity = entityKey && contentState.getEntity(entityKey);
+  const entityData = entity?.data;
+  const type = entity?.type;
+
+  return { type: type || 'text', entityData };
 }
 
 export function setSelection(editorState, selection) {


### PR DESCRIPTION
### :bug: Bug Fix
  - `editor-common`
    - getBlockInfo returns entity type rather block type
