### PR TITLE
[plugin-link] fix: backslash in link panel breaks editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   - [#612](https://github.com/wix-incubator/rich-content/pull/612) warnings issues of google-maps-loader props
 - `editor-common`
   - [#642](https://github.com/wix-incubator/rich-content/pull/642) block selection is removed when losing focus
+- `link`
+  - [#646](https://github.com/wix-incubator/rich-content/pull/646) backslash in link panel breaks editor
 </details>
 <hr/>
 

--- a/examples/main/shared/editor/EditorPlugins.jsx
+++ b/examples/main/shared/editor/EditorPlugins.jsx
@@ -125,6 +125,7 @@ const getLinkPanelDropDownConfig = () => {
       searchWords={[searchWords]}
       textToHighlight={textToHighlight}
       highlightTag={({ children }) => <strong className="highlighted-text">{children}</strong>}
+      autoEscape
     />
   );
 


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
