### PR TITLE
[gallery] fix(*): add disableHover config for blog backward support

### DIFF
--- a/e2e/test-env/src/client/TestApp.jsx
+++ b/e2e/test-env/src/client/TestApp.jsx
@@ -1,11 +1,18 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import Editor from '../../../../examples/main/shared/editor/Editor';
 import Viewer from '../../../../examples/main/shared/viewer/Viewer';
-import PropTypes from 'prop-types';
 
 class TestApp extends PureComponent {
   renderEditor = () => {
-    const { initialState, onEditorChange, locale, localeResource, isMobile } = this.props;
+    const {
+      initialState,
+      onEditorChange,
+      locale,
+      localeResource,
+      isMobile,
+      additionalConfig,
+    } = this.props;
     return (
       <Editor
         onChange={onEditorChange}
@@ -15,13 +22,21 @@ class TestApp extends PureComponent {
         locale={locale}
         localeResource={localeResource}
         mockImageIndex={1}
+        additionalConfig={additionalConfig}
       />
     );
   };
 
   renderViewer = () => {
-    const { isMobile, viewerState, locale } = this.props;
-    return <Viewer initialState={viewerState} isMobile={isMobile} locale={locale} />;
+    const { isMobile, viewerState, locale, additionalConfig } = this.props;
+    return (
+      <Viewer
+        additionalConfig={additionalConfig}
+        initialState={viewerState}
+        isMobile={isMobile}
+        locale={locale}
+      />
+    );
   };
 
   render() {
@@ -47,6 +62,7 @@ TestApp.propTypes = {
   viewerState: PropTypes.object,
   initialState: PropTypes.object,
   localeResource: PropTypes.object,
+  additionalConfig: PropTypes.object,
   onEditorChange: PropTypes.func,
 };
 

--- a/examples/main/shared/RichContentApp.jsx
+++ b/examples/main/shared/RichContentApp.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 import { convertToRaw, createEmpty } from 'wix-rich-content-editor/dist/lib/editorStateConversion';
 import { isSSR } from 'wix-rich-content-common';
+import { GALLERY_TYPE } from 'wix-rich-content-plugin-gallery';
 import ExampleApp from '../src/ExampleApp';
 import TestApp from '../../../e2e/test-env/src/client/TestApp';
 import { getRequestedLocale, isMobile } from '../src/utils';
@@ -47,6 +48,11 @@ class RichContentApp extends PureComponent {
     const { editorState, viewerState, localeResource, locale } = this.state;
     const { allLocales, initialState, mode } = this.props;
     const App = mode === 'demo' ? ExampleApp : TestApp;
+    const additionalConfig = {
+      [GALLERY_TYPE]: {
+        disableHover: true,
+      },
+    };
     return (
       <App
         allLocales={allLocales}
@@ -59,6 +65,7 @@ class RichContentApp extends PureComponent {
         localeResource={localeResource}
         onEditorChange={this.onEditorChange}
         setLocale={this.setLocaleResource}
+        additionalConfig={additionalConfig}
       />
     );
   }

--- a/examples/main/shared/RichContentApp.jsx
+++ b/examples/main/shared/RichContentApp.jsx
@@ -50,7 +50,7 @@ class RichContentApp extends PureComponent {
     const App = mode === 'demo' ? ExampleApp : TestApp;
     const additionalConfig = {
       [GALLERY_TYPE]: {
-        disableHover: true,
+        disableHoverDefault: true,
       },
     };
     return (

--- a/examples/main/shared/editor/Editor.jsx
+++ b/examples/main/shared/editor/Editor.jsx
@@ -7,7 +7,7 @@ import { testImages, testVideos } from './mock';
 import * as Plugins from './EditorPlugins';
 import ModalsMap from './ModalsMap';
 import theme from '../theme/theme'; // must import after custom styles
-import { GALLERY_TYPE } from 'wix-rich-content-plugin-gallery';
+
 const modalStyleDefaults = {
   content: {
     top: '50%',
@@ -28,8 +28,7 @@ export default class Editor extends PureComponent {
     super(props);
     // ReactModal.setAppElement('#root');
     this.initEditorProps();
-    const { scrollingElementFn } = props;
-    const additionalConfig = { [GALLERY_TYPE]: { scrollingElement: scrollingElementFn } };
+    const { additionalConfig } = props;
     this.pluginsConfig = Plugins.getConfig(additionalConfig);
   }
 
@@ -194,7 +193,6 @@ export default class Editor extends PureComponent {
           onChange={this.handleChange}
           helpers={this.helpers}
           plugins={Plugins.editorPlugins}
-          // config={Plugins.getConfig(additionalConfig)}
           config={this.pluginsConfig}
           editorKey="random-editorKey-ssr"
           // siteDomain="https://www.wix.com"

--- a/examples/main/shared/viewer/Viewer.jsx
+++ b/examples/main/shared/viewer/Viewer.jsx
@@ -7,7 +7,6 @@ import * as Plugins from './ViewerPlugins';
 import theme from '../theme/theme'; // must import after custom styles
 import getImagesData from 'wix-rich-content-fullscreen/src/lib/getImagesData';
 import Fullscreen from 'wix-rich-content-fullscreen';
-import { GALLERY_TYPE } from 'wix-rich-content-plugin-gallery';
 const anchorTarget = '_top';
 const relValue = 'noreferrer';
 
@@ -23,8 +22,7 @@ export default class Viewer extends PureComponent {
       disabled: false,
     };
 
-    const { scrollingElementFn } = props;
-    const additionalConfig = { [GALLERY_TYPE]: { scrollingElement: scrollingElementFn } };
+    const { additionalConfig } = props;
     this.pluginsConfig = Plugins.getConfig(additionalConfig);
   }
 

--- a/examples/main/src/ExampleApp.jsx
+++ b/examples/main/src/ExampleApp.jsx
@@ -12,6 +12,8 @@ import {
   SectionContent,
 } from './Components';
 import { generateKey, getStateFromObject, loadStateFromStorage, saveStateToStorage } from './utils';
+import { GALLERY_TYPE } from 'wix-rich-content-plugin-gallery';
+
 const Editor = React.lazy(() => import('../shared/editor/Editor'));
 const Viewer = React.lazy(() => import('../shared/viewer/Viewer'));
 const Preview = React.lazy(() => import('../shared/preview/Preview'));
@@ -136,6 +138,12 @@ class ExampleApp extends PureComponent {
 
     const scrollingElementFn = () =>
       typeof window !== 'undefined' && document.getElementsByClassName('editor-example')[0];
+
+    const additionalConfig = {
+      [GALLERY_TYPE]: {
+        scrollingElement: scrollingElementFn,
+      },
+    };
     return (
       isEditorShown && (
         <ReflexElement
@@ -158,7 +166,7 @@ class ExampleApp extends PureComponent {
                 staticToolbar={staticToolbar}
                 locale={locale}
                 localeResource={localeResource}
-                scrollingElementFn={scrollingElementFn}
+                additionalConfig={additionalConfig}
               />
             </ErrorBoundary>
           </SectionContent>
@@ -222,6 +230,11 @@ class ExampleApp extends PureComponent {
     const scrollingElementFn = () =>
       typeof window !== 'undefined' && document.getElementsByClassName('viewer-example')[0];
 
+    const additionalConfig = {
+      [GALLERY_TYPE]: {
+        scrollingElement: scrollingElementFn,
+      },
+    };
     return (
       isViewerShown && (
         <ReflexElement
@@ -240,7 +253,7 @@ class ExampleApp extends PureComponent {
                 isMobile={this.state.viewerIsMobile || isMobile}
                 locale={locale}
                 localeResource={localeResource}
-                scrollingElementFn={scrollingElementFn}
+                additionalConfig={additionalConfig}
               />
             </ErrorBoundary>
           </SectionContent>

--- a/examples/storybook/stories/Components/StoryParts.js
+++ b/examples/storybook/stories/Components/StoryParts.js
@@ -41,7 +41,7 @@ Section.propTypes = {
 export const RichContentEditorBox = ({ children, preset, title }) => {
   return (
     <div className={`${styles[preset || '']}`}>
-      {title && <h2>Editor!</h2>}
+      {title && <h2>Editor</h2>}
       <div className={styles.rceWrapper}>{children}</div>
     </div>
   );

--- a/examples/storybook/stories/index.js
+++ b/examples/storybook/stories/index.js
@@ -3,5 +3,6 @@ import './styles.global.scss';
 require('./Intro/');
 require('./Editor/');
 require('./Viewer/');
+require('./Plugins/');
 require('./Wrapper/');
 require('./TestCase/');

--- a/examples/storybook/stories/styles.global.scss
+++ b/examples/storybook/stories/styles.global.scss
@@ -4,6 +4,7 @@
 @import '~wix-rich-content-editor/dist/styles.min.css';
 @import '~wix-rich-content-viewer/dist/styles.min.css';
 @import '~wix-rich-content-plugin-divider/dist/styles.min.css';
+@import '~wix-rich-content-plugin-gallery/dist/styles.min.css';
 @import '~wix-rich-content-plugin-image/dist/styles.min.css';
 @import '~wix-rich-content-plugin-link/dist/styles.min.css';
 @import '~wix-rich-content-plugin-html/dist/styles.min.css';

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
@@ -146,12 +146,16 @@ class RichContentEditor extends Component {
   });
 
   getInitialEditorState() {
-    const { editorState, initialState, anchorTarget, relValue } = this.props;
+    const { editorState, initialState, anchorTarget, relValue, config } = this.props;
     if (editorState) {
       return editorState;
     }
     if (initialState) {
-      const rawContentState = normalizeInitialState(initialState, { anchorTarget, relValue });
+      const rawContentState = normalizeInitialState(initialState, {
+        anchorTarget,
+        relValue,
+        config,
+      });
       return EditorState.createWithContent(convertFromRaw(rawContentState));
     } else {
       const emptyContentState = convertFromRaw({

--- a/packages/plugin-divider/web/src/components/divider-line.jsx
+++ b/packages/plugin-divider/web/src/components/divider-line.jsx
@@ -55,7 +55,7 @@ DividerLine.propTypes = {
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   multilineDistance: PropTypes.number,
   fillParent: PropTypes.bool,
-  isMobile: PropTypes.bool.isRequired,
+  isMobile: PropTypes.bool,
 };
 
 export default DividerLine;

--- a/packages/plugin-gallery/web/package.json
+++ b/packages/plugin-gallery/web/package.json
@@ -28,7 +28,8 @@
     "build:analyze": "npm run build -- --environment MODULE_ANALYZE && open stats.html",
     "postbuild": "node ../../../scripts/esCheck.js",
     "watch": "cross-env NODE_ENV=development MODULE_WATCH=1 npm run build -- --watch.chokidar",
-    "lint": "eslint 'src/**/*.{js,jsx}'"
+    "lint": "eslint 'src/**/*.{js,jsx}'",
+    "test:watch": "jest --watch"
   },
   "peerDependencies": {
     "@babel/runtime": "7.2.0",
@@ -50,7 +51,8 @@
     "prop-types": "^15.6.2",
     "react": "16.6.3",
     "react-dom": "16.6.3",
-    "rollup": "1.20.3"
+    "rollup": "1.20.3",
+    "jest": "^23.1.0"
   },
   "dependencies": {
     "image-client-api": "1.2218.0",
@@ -62,5 +64,17 @@
   "unpkg": true,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
+  },
+  "jest": {
+    "globals": {
+      "NODE_ENV": "test"
+    },
+    "transform": {
+      "^.+\\.jsx?$": "<rootDir>/../../../babel.jest.monorepo.js"
+    },
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|svg)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js"
+    }
   }
 }

--- a/packages/plugin-gallery/web/src/components/gallery-controls/gallery-image-settings.js
+++ b/packages/plugin-gallery/web/src/components/gallery-controls/gallery-image-settings.js
@@ -19,15 +19,20 @@ import GallerySettingsMobileHeader from './gallery-settings-mobile-header';
 class ImageSettings extends Component {
   constructor(props) {
     super(props);
-    this.styles = mergeStyles({ styles, theme: props.theme });
+    const {
+      theme,
+      image: { disableHover },
+    } = props;
+    this.styles = mergeStyles({ styles, theme });
     const { t } = props;
-    this.updateLabel = t('GalleryImageSettings_Update');
-    this.headerLabel = t('GalleryImageSettings_Header');
-    this.ReplaceLabel = t('GalleryImageSettings_Replace_Label');
-    this.deleteLabel = t('GalleryImageSettings_Delete_Label');
-    this.titleLabel = t('GalleryImageSettings_Title_Label');
-    this.titleInputPlaceholder = t('GalleryImageSettings_Title_Input_Placeholder');
-    this.linkLabel = t('GalleryImageSettings_Link_Label');
+    const prefix = 'GalleryImageSettings';
+    this.updateLabel = t(`${prefix}_Update`);
+    this.headerLabel = t(`${prefix}_Header`);
+    this.ReplaceLabel = t(`${prefix}_Replace_Label`);
+    this.deleteLabel = t(`${prefix}_Delete_Label`);
+    this.titleLabel = t(`${disableHover ? 'ImageSettings_Alt_Label' : `${prefix}_Title_Label`}`);
+    this.titleInputPlaceholder = t(`${prefix}_Title_Input_Placeholder`);
+    this.linkLabel = t(`${prefix}_Link_Label`);
   }
 
   deleteImage() {
@@ -264,6 +269,7 @@ ImageSettings.propTypes = {
   image: PropTypes.shape({
     url: PropTypes.string.isRequired,
     metadata: PropTypes.object.isRequired,
+    disableHover: PropTypes.bool,
   }).isRequired,
   onCancel: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,

--- a/packages/plugin-gallery/web/src/components/gallery-controls/gallery-items-sortable.js
+++ b/packages/plugin-gallery/web/src/components/gallery-controls/gallery-items-sortable.js
@@ -16,10 +16,6 @@ import { FileInput } from 'wix-rich-content-editor-common';
 
 import { FabIcon, UploadIcon, SelectedIcon, NotSelectedIcon } from '../../icons';
 
-//eslint-disable-next-line no-unused-vars
-const EMPTY_SMALL_PLACEHOLDER =
-  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-
 const onKeyDown = (e, handler) => {
   if (e.key === 'Enter' || e.key === ' ') {
     handler();

--- a/packages/plugin-gallery/web/src/components/gallery-settings-modal.js
+++ b/packages/plugin-gallery/web/src/components/gallery-settings-modal.js
@@ -47,25 +47,30 @@ class ManageMediaSection extends Component {
       isMobile,
       uiSettings,
       languageDir,
+      theme,
+      data,
     } = this.props;
     const { handleFileSelection } = helpers;
 
+    const { items } = data;
+
+    const sortableComponentProps = {
+      theme,
+      items,
+      t,
+      relValue,
+      anchorTarget,
+      isMobile,
+      uiSettings,
+      onItemsChange: this.applyItems,
+      handleFileChange: this.handleFileChange,
+      handleFileSelection: handleFileSelection && this.handleFileSelection,
+      handleFilesAdded: store.getBlockHandler('handleFilesAdded'),
+      deleteBlock: store.get('deleteBlock'),
+    };
     return (
       <div dir={languageDir}>
-        <SortableComponent
-          theme={this.props.theme}
-          items={this.props.data.items}
-          onItemsChange={this.applyItems}
-          handleFileChange={this.handleFileChange}
-          handleFileSelection={handleFileSelection && this.handleFileSelection}
-          handleFilesAdded={store.getBlockHandler('handleFilesAdded')}
-          deleteBlock={store.get('deleteBlock')}
-          t={t}
-          relValue={relValue}
-          anchorTarget={anchorTarget}
-          isMobile={isMobile}
-          uiSettings={uiSettings}
-        />
+        <SortableComponent {...sortableComponentProps} />
       </div>
     );
   }

--- a/packages/plugin-gallery/web/src/constants.js
+++ b/packages/plugin-gallery/web/src/constants.js
@@ -74,3 +74,14 @@ export const DEFAULTS = Object.freeze({
 
 export const isHorizontalLayout = ({ galleryLayout }) =>
   HORIZONTAL_LAYOUTS.indexOf(galleryLayout) > -1;
+
+export const BASE_MOBILE_STYLES = {
+  allowTitle: true,
+  galleryTextAlign: 'center',
+  textsHorizontalPadding: 0,
+  imageInfoType: 'NO_BACKGROUND',
+  hoveringBehaviour: 'APPEARS',
+  textsVerticalPadding: 0,
+  titlePlacement: 'SHOW_BELOW',
+  calculateTextBoxHeightMode: 'AUTOMATIC',
+};

--- a/packages/plugin-gallery/web/src/gallery-component.jsx
+++ b/packages/plugin-gallery/web/src/gallery-component.jsx
@@ -4,10 +4,6 @@ import { isEqual } from 'lodash';
 import GalleryViewer from './gallery-viewer';
 import { DEFAULTS } from './constants';
 
-//eslint-disable-next-line no-unused-vars
-const EMPTY_SMALL_PLACEHOLDER =
-  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-
 class GalleryComponent extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/plugin-gallery/web/src/gallery-viewer.jsx
+++ b/packages/plugin-gallery/web/src/gallery-viewer.jsx
@@ -76,11 +76,11 @@ class GalleryViewer extends React.Component {
       isMobile,
       anchorTarget,
       relValue,
-      settings: { disableHover = false },
+      settings: { disableHoverDefault = false },
     } = props;
 
     const galleryDomain = new Gallery(componentData, {
-      disableHover,
+      disableHoverDefault,
       isMobile,
       anchorTarget,
       relValue,
@@ -139,10 +139,10 @@ class GalleryViewer extends React.Component {
 
   hoverElement = itemProps => {
     const {
-      settings: { disableHover = false },
+      settings: { disableHoverDefault = false },
     } = this.props;
     return (
-      !disableHover && (
+      !disableHoverDefault && (
         <Fragment>
           {this.renderExpandIcon(itemProps)}
           {this.renderTitle(itemProps.alt)}

--- a/packages/viewer/web/src/RichContentViewer.jsx
+++ b/packages/viewer/web/src/RichContentViewer.jsx
@@ -23,13 +23,16 @@ class RichContentViewer extends Component {
     this.styles = mergeStyles({ styles, theme: props.theme });
   }
 
-  static getInitialState = props =>
-    props.initialState
-      ? normalizeInitialState(props.initialState, {
-          anchorTarget: props.anchorTarget,
-          relValue: props.relValue,
+  static getInitialState = props => {
+    const { initialState, anchorTarget, relValue, config } = props;
+    return initialState
+      ? normalizeInitialState(initialState, {
+          anchorTarget,
+          relValue,
+          config,
         })
       : {};
+  };
 
   initContext = () => {
     const {


### PR DESCRIPTION
Didn't end up using versioning, because in the example they reported it already updated to version 6 so won't fix.
Used additional gallery config, that we can later on use to add the needed checkbox to display alt-text as title. for now it just resolve the urgency for blog and restore the behvaior so they continue with upgrading