### PR TITLE
ignore loader css for rtl, as animation handling is bugged in postcss…

### DIFF
--- a/packages/common/web/statics/styles/loaders.rtlignore.scss
+++ b/packages/common/web/statics/styles/loaders.rtlignore.scss
@@ -1,5 +1,5 @@
 @import './palette';
-
+/* rtl:begin:ignore */
 .loaderOverlay {
   position: relative;
   width: 100%;
@@ -67,3 +67,4 @@
       0 -0.83em 0 -0.477em;
   }
 }
+/* rtl:end:ignore */


### PR DESCRIPTION
Loader is broken for us due to bug in rtl css lib see https://github.com/vkalinichev/postcss-rtl/issues/61