### PR TITLE
[react-modal] fix: mouse up event on overlay triggered the closing the modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@
     Changes that have landed in master but are not yet released.
     Click to see more.
   </summary>
-
+  
+### :bug: [Bug Fix]
+- `general`
+  - [#843](https://github.com/wix-incubator/rich-content/pull/843) fix: mouse up event on overlay triggered the closing the modals
 
 </details>
 <hr/>

--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -29,7 +29,7 @@
     "react-hot-loader": "4.11.0",
     "react-icons": "~3.7.0",
     "react-json-editor-ajrm": "^2.5.3",
-    "react-modal": "~3.1.11",
+    "react-modal": "~3.4.1",
     "react-monaco-editor": "^0.26.1",
     "react-reflex": "^3.0.13",
     "react-tiny-fab": "^2.0.0",

--- a/packages/plugin-line-spacing/web/package.json
+++ b/packages/plugin-line-spacing/web/package.json
@@ -48,7 +48,7 @@
     "rollup": "1.31.1"
   },
   "dependencies": {
-    "react-modal": "~3.1.11",
+    "react-modal": "~3.4.1",
     "wix-rich-content-common": "7.1.2",
     "wix-rich-content-editor-common": "7.1.2"
   },

--- a/packages/plugin-text-color/web/package.json
+++ b/packages/plugin-text-color/web/package.json
@@ -50,7 +50,7 @@
     "rollup": "1.31.1"
   },
   "dependencies": {
-    "react-modal": "~3.1.11",
+    "react-modal": "~3.4.1",
     "wix-rich-content-common": "7.1.2",
     "wix-rich-content-editor-common": "7.1.2"
   },

--- a/packages/wrapper/web/package.json
+++ b/packages/wrapper/web/package.json
@@ -59,7 +59,7 @@
     "jss-plugin-camel-case": "^10.1.1",
     "jss-plugin-nested": "^10.1.1",
     "jss-preset-default": "^10.1.1",
-    "react-modal": "~3.1.11",
+    "react-modal": "~3.4.1",
     "wix-rich-content-common": "7.1.2",
     "wix-rich-content-editor": "7.1.2",
     "wix-rich-content-editor-common": "7.1.2",


### PR DESCRIPTION


<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
