### PR TITLE
[general] fix: max-width set to all plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - `link-preview`
   - [#871](https://github.com/wix-incubator/rich-content/pull/871) maxwidth
 - `general`
-  - [#889](https://github.com/wix-incubator/rich-content/pull/889) fix all plugins max-width on resize
+  - [#889](https://github.com/wix-incubator/rich-content/pull/889) fix all plugins max-width for inline size
 
 ### :house: Internal
 - `general`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@
   - [#879](https://github.com/wix-incubator/rich-content/pull/879) blurry pictures & not rendering
   - [#877](https://github.com/wix-incubator/rich-content/pull/877) fix gallery plugin blurry pictures
 - `link-preview`
-  - [#871](https://github.com/wix-incubator/rich-content/pull/871) embed link width 
+  - [#871](https://github.com/wix-incubator/rich-content/pull/871) embed link width
+- `general`
+  - [#889](https://github.com/wix-incubator/rich-content/pull/889) fix all plugins max-width on resize
 
 ### :house: Internal
 - `general`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   - [#879](https://github.com/wix-incubator/rich-content/pull/879) blurry pictures & not rendering
   - [#877](https://github.com/wix-incubator/rich-content/pull/877) fix gallery plugin blurry pictures
 - `link-preview`
-  - [#871](https://github.com/wix-incubator/rich-content/pull/871) embed link width
+  - [#871](https://github.com/wix-incubator/rich-content/pull/871) maxwidth
 - `general`
   - [#889](https://github.com/wix-incubator/rich-content/pull/889) fix all plugins max-width on resize
 

--- a/packages/common/web/statics/styles/general.rtlignore.scss
+++ b/packages/common/web/statics/styles/general.rtlignore.scss
@@ -43,6 +43,7 @@
   &:not(.textWrapNowrap):not(.sizeFullWidth) {
     margin-left: auto;
     margin-right: auto;
+    max-width: 100%;
   }
 }
 

--- a/packages/plugin-html/web/src/HtmlComponent.jsx
+++ b/packages/plugin-html/web/src/HtmlComponent.jsx
@@ -92,6 +92,7 @@ class HtmlComponent extends Component {
       width: this.props.isMobile ? 'auto' : currentWidth || width || INIT_WIDTH,
       height: this.state.iframeHeight || height || INIT_HEIGHT,
       maxHeight: this.state.iframeHeight,
+      maxWidth: '100%',
     };
 
     return (

--- a/packages/viewer/web/statics/rich-content-viewer.scss
+++ b/packages/viewer/web/statics/rich-content-viewer.scss
@@ -61,7 +61,6 @@
 
 .atomic {
   margin: 2px 0;
-  max-width: 100%;
 }
 
 .toolbar {

--- a/packages/viewer/web/statics/rich-content-viewer.scss
+++ b/packages/viewer/web/statics/rich-content-viewer.scss
@@ -61,6 +61,7 @@
 
 .atomic {
   margin: 2px 0;
+  max-width: 100%;
 }
 
 .toolbar {


### PR DESCRIPTION
Click below to open examples:
rich-content: https://rich-content-maxSizePluginsEditorViewer.surge.sh/
rich-content-storybook: https://rich-content-storybook-maxSizePluginsEditorViewer.surge.sh/