### PR TITLE
[editor] use cjs version of UrlInputModal

### DIFF
--- a/packages/plugin-link-preview/web/src/toolbar/embedURLInputModal.jsx
+++ b/packages/plugin-link-preview/web/src/toolbar/embedURLInputModal.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isValidUrl } from 'wix-rich-content-common';
-import UrlInputModal from 'wix-rich-content-editor-common/dist/lib/UrlInputModal';
+import UrlInputModal from 'wix-rich-content-editor-common/dist/lib/UrlInputModal.cjs.js';
 import { DEFAULTS } from '../consts';
 
 export default class EmbedURLInputModal extends Component {

--- a/packages/plugin-sound-cloud/web/src/toolbar/soundCloudURLInputModal.jsx
+++ b/packages/plugin-sound-cloud/web/src/toolbar/soundCloudURLInputModal.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactPlayer from 'react-player';
-import UrlInputModal from 'wix-rich-content-editor-common/dist/lib/UrlInputModal';
+import UrlInputModal from 'wix-rich-content-editor-common/dist/lib/UrlInputModal.cjs.js';
 
 export default class SoundCloudURLInputModal extends Component {
   constructor(props) {


### PR DESCRIPTION
Click below to open examples:
rich-content: https://rich-content-UrlInputModalCjs.surge.sh/
rich-content-storybook: https://rich-content-storybook-UrlInputModalCjs.surge.sh/