### PR TITLE
[wrapper] BM palette will appear as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@
   - [#929](https://github.com/wix-incubator/rich-content/pull/929) fix: empty lists viewer issues
 ### :house: Internal
 - `vertical-embed`
-  -  [#728](https://github.com/wix-incubator/rich-content/pull/728) Vertical Embed Plugin - alpha verison
-- 'viewer'
+  - [#728](https://github.com/wix-incubator/rich-content/pull/728) Vertical Embed Plugin - alpha verison
+- `viewer`
   - [#908](https://github.com/wix-incubator/rich-content/pull/908) Support Viewer predefined anchors
-
-  
+- `wrapper`
+  - [#935](https://github.com/wix-incubator/rich-content/pull/935) back-office theme will appear as default theme for now  
 
 </details>
 <hr/>

--- a/packages/wrapper/web/src/themeStrategy/ThemeGenerator.spec.ts
+++ b/packages/wrapper/web/src/themeStrategy/ThemeGenerator.spec.ts
@@ -22,9 +22,9 @@ describe('ThemeGenerator', () => {
       expect(func).toThrow();
     });
 
-    it('should expect site colors if theme is back office', () => {
+    it('should expect default behavior if theme is back office', () => {
       const func = () => createTheme(false, { theme: THEMES.BACK_OFFICE });
-      expect(func).toThrow();
+      expect(func).not.toThrow();
     });
 
     it('should create theme object', () => {

--- a/packages/wrapper/web/src/themeStrategy/ThemeGenerator.ts
+++ b/packages/wrapper/web/src/themeStrategy/ThemeGenerator.ts
@@ -11,7 +11,7 @@ const THEMES = {
   PALETTE: 'Palette',
 };
 
-const SUPPORTED_THEMES = [THEMES.DEFAULT, THEMES.PALETTE, THEMES.BACK_OFFICE];
+const SUPPORTED_THEMES = [THEMES.DEFAULT, THEMES.PALETTE];
 const BG_COLOR = 11;
 const SECONDARY_COLOR = 13;
 const COLOR4 = 14;
@@ -38,7 +38,7 @@ export default class ThemeGenerator {
     if (SUPPORTED_THEMES.indexOf(theme) === -1) this._theme = THEMES.DEFAULT;
     else this._theme = theme;
 
-    if (theme === THEMES.PALETTE || theme === THEMES.BACK_OFFICE) {
+    if (theme === THEMES.PALETTE) {
       if (!palette) throw Error('Invalid palette');
       else this.palette = palette;
     }


### PR DESCRIPTION
Click below to open examples:
rich-content: https://rich-content-wrapper-bm-fix.surge.sh/
rich-content-storybook: https://rich-content-storybook-wrapper-bm-fix.surge.sh/