### PR TITLE
[emoji] fix dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   - [#957](https://github.com/wix-incubator/rich-content/pull/957) fix: command+ctrl+j creates code block on mac
 - `map`
   - [#959](https://github.com/wix-incubator/rich-content/pull/959) modal settings fixed (convention) & made compatible with wrapper palette colors
+- `emoji`
+  - [#959](https://github.com/wix-incubator/rich-content/pull/959) was using old editor and editor-common dependencies
 ### :house: Internal
 - `editor`
   - [#936](https://github.com/wix-incubator/rich-content/pull/936) arrangement of inline toolbar buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - `map`
   - [#959](https://github.com/wix-incubator/rich-content/pull/959) modal settings fixed (convention) & made compatible with wrapper palette colors
 - `emoji`
-  - [#959](https://github.com/wix-incubator/rich-content/pull/959) was using old editor and editor-common dependencies
+  - [#973](https://github.com/wix-incubator/rich-content/pull/973) was using old editor and editor-common dependencies
 ### :house: Internal
 - `editor`
   - [#936](https://github.com/wix-incubator/rich-content/pull/936) arrangement of inline toolbar buttons

--- a/packages/plugin-emoji/web/package.json
+++ b/packages/plugin-emoji/web/package.json
@@ -52,8 +52,8 @@
   },
   "dependencies": {
     "react-custom-scrollbars": "^4.2.1",
-    "wix-rich-content-common": "7.1.3",
-    "wix-rich-content-editor-common": "7.1.3"
+    "wix-rich-content-common": "7.3.5",
+    "wix-rich-content-editor-common": "7.3.5"
   },
   "unpkg": true,
   "publishConfig": {


### PR DESCRIPTION
Packages that shrank:
viewer-with-wrapper: 524KB => 174KB
editor-with-emoji: 1111KB => 927KB
editor-with-basic-plugins: 1492KB => 1279KB

Please update the baseline file by running locally "npm run analyzeBundles" and push the changes.
