### PR TITLE
[editor-common] fix:When a plugin is created,  the selection is on the plugin but you still have the curser in the text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
     Click to see more.
   </summary>
 
+### :bug: Bug Fix
+- `editor-common`
+  - [#994](https://github.com/wix-incubator/rich-content/pull/994) fix:When a plugin is created, the selection is on the plugin but you still have the curser in the text
 ### :house: Internal
 - `wrapper`
   - [#980](https://github.com/wix-incubator/rich-content/pull/980) hotfix: createEmpty import

--- a/packages/editor-common/web/src/Base/createBaseInsertPluginButton.jsx
+++ b/packages/editor-common/web/src/Base/createBaseInsertPluginButton.jsx
@@ -56,6 +56,7 @@ export default ({
         data,
         blockType
       );
+      window.getSelection().removeAllRanges();
       setEditorState(EditorState.forceSelection(newEditorState, newSelection));
       return { newBlock, newSelection, newEditorState };
     };

--- a/packages/editor-common/web/src/Base/createBaseInsertPluginButton.jsx
+++ b/packages/editor-common/web/src/Base/createBaseInsertPluginButton.jsx
@@ -119,6 +119,7 @@ export default ({
           ? this.createBlocksFromFiles([files], galleryData, galleryType, updateEntity)
           : this.createBlocksFromFiles(files, button.componentData, blockType, updateEntity);
 
+        window.getSelection().removeAllRanges();
         this.props.setEditorState(EditorState.forceSelection(newEditorState, newSelection));
       }
     };


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
