### PR TITLE
Remove draft js references

### DIFF
--- a/packages/editor/web/src/RichContentEditor/handleBackspaceCommand.js
+++ b/packages/editor/web/src/RichContentEditor/handleBackspaceCommand.js
@@ -4,7 +4,6 @@ import {
   isAtomicBlockFocused,
   replaceWithEmptyBlock,
   indentSelectedBlocks,
-  getCharacterBeforeSelection,
   getSelectedBlocks,
 } from 'wix-rich-content-editor-common';
 import removeBlockAdjacentToAtomic from './atomicBlockRemovalUtil';

--- a/packages/plugin-headings/web/src/toolbar/HeadingButton.jsx
+++ b/packages/plugin-headings/web/src/toolbar/HeadingButton.jsx
@@ -5,8 +5,8 @@ import {
   InlineToolbarButton,
   EditorState,
   DEFAULT_HEADERS_DROPDOWN_OPTIONS,
+  RichUtils,
 } from 'wix-rich-content-editor-common';
-import { RichUtils } from 'draft-js';
 import Modal from 'react-modal';
 import HeadingsDropDownPanel from './HeadingPanel';
 import classNames from 'classnames';

--- a/packages/plugin-link-preview/web/src/lib/utils.js
+++ b/packages/plugin-link-preview/web/src/lib/utils.js
@@ -1,12 +1,15 @@
 import { DEFAULTS } from '../defaults';
 import { LINK_PREVIEW_TYPE } from '../types';
-import { SelectionState, EditorState, Modifier, RichUtils } from 'draft-js';
 import {
   getBlockAtStartOfSelection,
   replaceWithEmptyBlock,
   insertLinkInPosition,
   createBlock,
   deleteBlockText,
+  SelectionState,
+  EditorState,
+  Modifier,
+  RichUtils,
 } from 'wix-rich-content-editor-common';
 
 const addLinkPreview = async (editorState, config, blockKey, url) => {

--- a/packages/plugin-link-preview/web/src/lib/utils.js
+++ b/packages/plugin-link-preview/web/src/lib/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import { DEFAULTS } from '../defaults';
 import { LINK_PREVIEW_TYPE } from '../types';
 import {

--- a/packages/plugin-vertical-embed/web/package.json
+++ b/packages/plugin-vertical-embed/web/package.json
@@ -35,7 +35,6 @@
   "peerDependencies": {
     "@babel/runtime": "7.2.0",
     "classnames": "^2.0.0",
-    "draft-js": "0.11.2",
     "lodash": "^4.0.0",
     "prop-types": "^15.0.0",
     "react": "^16.6.3",
@@ -46,7 +45,6 @@
     "classnames": "^2.2.6",
     "concurrently": "^5.2.0",
     "cross-env": "^5.2.0",
-    "draft-js": "0.11.2",
     "eslint": "^6.1.0",
     "lodash": "^4.17.15",
     "prop-types": "^15.6.2",


### PR DESCRIPTION
we shouldn't import directly draft-js no more since we're using @wix/draft-js
