### PR TITLE
[ricos] fix JSS big warning in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
     Click to see more.
   </summary>
 
-
+### :house: Internal
+- `ricos`
+  - [#1121](https://github.com/wix-incubator/rich-content/pull/1121) fix JSS big warning in console (classnames not found)
 </details>
 <hr/>
 

--- a/packages/plugin-button/web/src/defaults.js
+++ b/packages/plugin-button/web/src/defaults.js
@@ -51,5 +51,7 @@ export function createTheme(colors, utils) {
         backgroundColor: utils.hexToRgbA(actionColor, 0.1),
       },
     },
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    checkbox_icon_unchecked: {},
   };
 }

--- a/packages/plugin-map/web/src/constants.js
+++ b/packages/plugin-map/web/src/constants.js
@@ -58,6 +58,7 @@ export const THEME = (colors, utils) => {
         backgroundColor: utils.fallbackColorBright,
       },
     },
+    labeled_toggle_track: {},
     labeled_toggle_switch: {},
     labeled_toggle_track_checked: {},
     labeled_toggle_slider: {},


### PR DESCRIPTION
Fixes 2 warnings of classnames not found:
- `checkbox_icon_unchecked`
- `labeled_toggle_track`

Example:
![image](https://user-images.githubusercontent.com/22775305/83769549-adcedd80-a688-11ea-86a5-d26c73f91e48.png)
