### PR TITLE
[mobile plugin menu] fix: scrolling page when the menu is open bug

### DIFF
--- a/packages/editor-common/web/src/Utils/getModalStyles.js
+++ b/packages/editor-common/web/src/Utils/getModalStyles.js
@@ -33,7 +33,7 @@ const mobileModalStyles = {
 };
 
 const stickyButtomMobileStyles = {
-  overlay: mobileModalStyles.overlay,
+  overlay: { ...mobileModalStyles.overlay, position: 'fixed' },
   content: {
     width: '100%',
     bottom: 0,


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
