### PR TITLE
Fake loader increase duration

### DIFF
--- a/packages/editor-common/web/src/Components/Loader.jsx
+++ b/packages/editor-common/web/src/Components/Loader.jsx
@@ -52,11 +52,11 @@ class Loader extends React.Component {
     if (!percent) {
       let approximateExpectedDuration;
       if (this.props.isFastFakeLoader) {
-        approximateExpectedDuration = 5000;
+        approximateExpectedDuration = 8500;
       }
 
       if (this.props.isVerySlowFakeLoader) {
-        approximateExpectedDuration = 30000;
+        approximateExpectedDuration = 50000;
       }
       this.resetFakeLoader = createFakeProgressStepper(
         percent => this.setState({ percent }),


### PR DESCRIPTION
Increase loader durations, so it's more inline with real world results of how long it takes to upload stuff.
