### PR TITLE
[editor] refactor(RichContentEditor) set/getEditorState concurrency

### DIFF
--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
@@ -296,9 +296,10 @@ class RichContentEditor extends Component {
   };
 
   updateEditorState = editorState => {
-    this.handleCallbacks(editorState, this.props.helpers);
-    this.setEditorState(editorState);
-    this.props.onChange?.(editorState);
+    this.setState({ editorState }, () => {
+      this.handleCallbacks(this.state.editorState, this.props.helpers);
+      this.props.onChange?.(this.state.editorState);
+    });
   };
 
   handleTabCommand = () => {


### PR DESCRIPTION
### :bug: Bug Fix
- `editor`
  - `onChange` and BI callbacks get the up to date editor state