### PR TITLE
add rtl:ignore before selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
   - [#1296](https://github.com/wix-incubator/rich-content/pull/1296) Editor Modal z-index increase
 - `common`
   - [#1310](https://github.com/wix-incubator/rich-content/pull/1310) long numbered list appears broken
+- `viewer`
+  - [#1318](https://github.com/wix-incubator/rich-content/pull/1318) add rtl-ignore comments
 ### :house: Internal
 - `plugins-bundle-analyzer`
   - [#1302](https://github.com/wix-incubator/rich-content/pull/1302) converted analyzer to typescript

--- a/packages/editor/web/statics/styles/rich-content-editor-alignment.rtlignore.scss
+++ b/packages/editor/web/statics/styles/rich-content-editor-alignment.rtlignore.scss
@@ -1,3 +1,4 @@
+/*!rtl:ignore*/
 .left {
   &>* {
     /*!rtl:ignore*/
@@ -11,6 +12,7 @@
   }
 }
 
+/*!rtl:ignore*/
 .right {
   &>* {
     /*!rtl:ignore*/

--- a/packages/viewer/web/statics/rich-content-viewer-alignment.rtlignore.scss
+++ b/packages/viewer/web/statics/rich-content-viewer-alignment.rtlignore.scss
@@ -1,5 +1,6 @@
 @import '~wix-rich-content-common/dist/statics/styles/general.rtlignore';
 
+/*! rtl:ignore */
 .left {
   /*!rtl:ignore*/
   text-align: left !important;
@@ -18,6 +19,7 @@
   }
 }
 
+/*! rtl:ignore */
 .right {
   /*!rtl:ignore*/
   text-align: right !important;

--- a/packages/viewer/web/statics/rich-content-viewer-rtl.rtlignore.scss
+++ b/packages/viewer/web/statics/rich-content-viewer-rtl.rtlignore.scss
@@ -1,9 +1,11 @@
+/*! rtl:ignore */
 .rtl {
     /*!rtl:begin:ignore*/
     direction: rtl;
     /*!rtl:end:ignore*/
   }
 
+/*! rtl:ignore */
 .ltr {
     /*!rtl:begin:ignore*/
     direction: ltr;


### PR DESCRIPTION
Added rtl:ignore comments before the whole rule, because otherwise yoshi still creates `[dir=ltr] .class` and `[dir=rtl] .class` versions of the class, which we don't want.