### PR TITLE
[ricos] fix(themeStrategy): external parent class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
     Click to see more.
   </summary>
 
+### :bug: Bug Fix
+- `ricos`
+  - [#1375](https://github.com/wix-incubator/rich-content/pull/1375) theme fix for multiple instances of RicosEditor / RicosViewer
 
 </details>
 <hr/>

--- a/docs/docs/ricos/ricos-api.mdx
+++ b/docs/docs/ricos/ricos-api.mdx
@@ -106,12 +106,26 @@ For rendering a viewer, import the plugin from the viewer entry point <br/> `wix
 ```jsx
 theme?: {
   palette?: Palette | PalettePreset
+  parentClass?: string;
 }
 ```
 
 #### `palette`
 
 Defines the palette of colors that will be used. More info in [Theming](theming)
+
+#### `parentClass`
+
+A parent css className that wraps a ricos instance.
+
+:::note
+This is a temporary solution for multiple instances of ricos inside TPA.
+You can ignore this field if you don't render multiple instances of ricos, or if you import package styles only once (which is the general case).
+:::
+
+Its purpose is to wrap palettes' classNames as if they were children of `parentClass`, in order to strenghten specifity of css & bypass duplicated style-imports.
+For example: Wix-TPA theme duplicates css files of `editor`/`editor-common`/`common` in each ricos component, and therefore overrides each one due to order of css.
+Defining a unique `parentClass` for each component overcomes this, as it creates unique style specifity for each instance.
 
 ## RicosEditor API
 

--- a/docs/docs/ricos/ricos-api.mdx
+++ b/docs/docs/ricos/ricos-api.mdx
@@ -117,15 +117,7 @@ Defines the palette of colors that will be used. More info in [Theming](theming)
 #### `parentClass`
 
 A parent css className that wraps a ricos instance.
-
-:::note
-This is a temporary solution for multiple instances of ricos inside TPA.
-You can ignore this field if you don't render multiple instances of ricos, or if you import package styles only once (which is the general case).
-:::
-
-Its purpose is to wrap palettes' classNames as if they were children of `parentClass`, in order to strenghten specifity of css & bypass duplicated style-imports.
-For example: Wix-TPA theme duplicates css files of `editor`/`editor-common`/`common` in each ricos component, and therefore overrides each one due to order of css.
-Defining a unique `parentClass` for each component overcomes this, as it creates unique style specifity for each instance.
+With this defined, dynamic styles will be wrapped by `parentClass` for CSS specifity.
 
 ## RicosEditor API
 

--- a/examples/storybook/stories/Components/EditorWrapper.js
+++ b/examples/storybook/stories/Components/EditorWrapper.js
@@ -163,7 +163,7 @@ class EditorWrapper extends React.Component {
       <RicosEditor
         ref={ref => (this.editor = ref)}
         plugins={this.editorPlugins}
-        theme={{ palette }}
+        theme={{ palette, parentClass: 'stories-Components-styles__rce-wrapper__1ks2F' }}
         content={content}
         isMobile={isMobile}
         placeholder={'Share something...'}

--- a/examples/storybook/stories/Components/EditorWrapper.js
+++ b/examples/storybook/stories/Components/EditorWrapper.js
@@ -163,7 +163,7 @@ class EditorWrapper extends React.Component {
       <RicosEditor
         ref={ref => (this.editor = ref)}
         plugins={this.editorPlugins}
-        theme={{ palette, parentClass: 'stories-Components-styles__rce-wrapper__1ks2F' }}
+        theme={{ palette }}
         content={content}
         isMobile={isMobile}
         placeholder={'Share something...'}

--- a/packages/ricos-common/web/src/RicosEngine.tsx
+++ b/packages/ricos-common/web/src/RicosEngine.tsx
@@ -74,7 +74,7 @@ export class RicosEngine extends Component<EngineProps, EngineState> {
     const { theme: themeStrategyResult, rawCss } = this.themeStrategy({
       isViewer,
       themeGeneratorFunctions,
-      palette: theme?.palette,
+      theme,
       cssOverride,
     });
 

--- a/packages/ricos-common/web/src/RicosTypes.ts
+++ b/packages/ricos-common/web/src/RicosTypes.ts
@@ -65,6 +65,7 @@ export interface RicosViewerProps extends RicosProps {
 
 export interface RicosTheme {
   palette?: Palette | PalettePreset;
+  parentClass?: string;
 }
 
 export type RichContentChild = ReactElement<ExportedRichContentProps>;

--- a/packages/ricos-common/web/src/themeStrategy/themeStrategy.spec.ts
+++ b/packages/ricos-common/web/src/themeStrategy/themeStrategy.spec.ts
@@ -9,8 +9,15 @@ describe('ThemeStrategy', () => {
     runStrategy: (
       themeGeneratorFunctions?: ThemeGeneratorFunction[],
       palette?: Palette,
+      parentClass?: string,
       cssOverride?: RicosCssOverride
-    ) => themeStrategy()({ isViewer: false, themeGeneratorFunctions, palette, cssOverride }),
+    ) =>
+      themeStrategy()({
+        isViewer: false,
+        themeGeneratorFunctions,
+        theme: { palette, parentClass },
+        cssOverride,
+      }),
   };
 
   it('should create a theme object', () => {
@@ -32,7 +39,7 @@ describe('ThemeStrategy', () => {
 
   it('should set inner props to override the default theme', () => {
     const cssOverride: RicosCssOverride = { modalTheme: { content: { backgroundColor: 'white' } } };
-    const themeStrategyResult = driver.runStrategy(undefined, undefined, cssOverride);
+    const themeStrategyResult = driver.runStrategy(undefined, undefined, undefined, cssOverride);
     expect(themeStrategyResult.theme?.modalTheme?.content).toStrictEqual({
       backgroundColor: 'white',
     });

--- a/packages/ricos-common/web/src/themeStrategy/themeStrategy.spec.ts
+++ b/packages/ricos-common/web/src/themeStrategy/themeStrategy.spec.ts
@@ -5,14 +5,20 @@ import { RicosCssOverride } from '../types';
 import { wixPalettes } from '../../../../../examples/storybook/stories/palettesExample';
 
 // eslint-disable-next-line mocha/no-skipped-tests
+interface strategyProps {
+  themeGeneratorFunctions?: ThemeGeneratorFunction[];
+  palette?: Palette;
+  parentClass?: string;
+  cssOverride?: RicosCssOverride;
+}
 describe('ThemeStrategy', () => {
   const driver = {
-    runStrategy: (
-      themeGeneratorFunctions?: ThemeGeneratorFunction[],
-      palette?: Palette,
-      parentClass?: string,
-      cssOverride?: RicosCssOverride
-    ) =>
+    runStrategy: ({
+      themeGeneratorFunctions,
+      palette,
+      parentClass,
+      cssOverride,
+    }: strategyProps = {}) =>
       themeStrategy()({
         isViewer: false,
         themeGeneratorFunctions,
@@ -40,7 +46,7 @@ describe('ThemeStrategy', () => {
 
   it('should set inner props to override the default theme', () => {
     const cssOverride: RicosCssOverride = { modalTheme: { content: { backgroundColor: 'white' } } };
-    const themeStrategyResult = driver.runStrategy(undefined, undefined, undefined, cssOverride);
+    const themeStrategyResult = driver.runStrategy({ cssOverride });
     expect(themeStrategyResult.theme?.modalTheme?.content).toStrictEqual({
       backgroundColor: 'white',
     });
@@ -49,12 +55,11 @@ describe('ThemeStrategy', () => {
   it('should wrap classnames with parentClass prop, if given with a palette', () => {
     const cssOverride: RicosCssOverride = { modalTheme: { content: { backgroundColor: 'white' } } };
     const dummyParent = 'dummyParentClassname';
-    const themeStrategyResult = driver.runStrategy(
-      undefined,
-      wixPalettes.site1,
-      dummyParent,
-      cssOverride
-    );
+    const themeStrategyResult = driver.runStrategy({
+      palette: wixPalettes.site1,
+      parentClass: dummyParent,
+      cssOverride,
+    });
     const { rawCss } = themeStrategyResult;
     expect(rawCss).toBeDefined();
     rawCss?.split('\n').forEach(line => {

--- a/packages/ricos-common/web/src/themeStrategy/themeStrategy.spec.ts
+++ b/packages/ricos-common/web/src/themeStrategy/themeStrategy.spec.ts
@@ -2,6 +2,7 @@ import themeStrategy from './themeStrategy';
 import getType from 'jest-get-type';
 import { Palette, ThemeGeneratorFunction } from './themeTypes';
 import { RicosCssOverride } from '../types';
+import { wixPalettes } from '../../../../../examples/storybook/stories/palettesExample';
 
 // eslint-disable-next-line mocha/no-skipped-tests
 describe('ThemeStrategy', () => {
@@ -42,6 +43,22 @@ describe('ThemeStrategy', () => {
     const themeStrategyResult = driver.runStrategy(undefined, undefined, undefined, cssOverride);
     expect(themeStrategyResult.theme?.modalTheme?.content).toStrictEqual({
       backgroundColor: 'white',
+    });
+  });
+
+  it('should wrap classnames with parentClass prop, if given with a palette', () => {
+    const cssOverride: RicosCssOverride = { modalTheme: { content: { backgroundColor: 'white' } } };
+    const dummyParent = 'dummyParentClassname';
+    const themeStrategyResult = driver.runStrategy(
+      undefined,
+      wixPalettes.site1,
+      dummyParent,
+      cssOverride
+    );
+    const { rawCss } = themeStrategyResult;
+    expect(rawCss).toBeDefined();
+    rawCss?.split('\n').forEach(line => {
+      if (line.startsWith('.')) expect(line.startsWith(`.${dummyParent} `)).toBeTruthy();
     });
   });
 });

--- a/packages/ricos-common/web/src/themeStrategy/themeStrategy.spec.ts
+++ b/packages/ricos-common/web/src/themeStrategy/themeStrategy.spec.ts
@@ -54,16 +54,16 @@ describe('ThemeStrategy', () => {
 
   it('should wrap classnames with parentClass prop, if given with a palette', () => {
     const cssOverride: RicosCssOverride = { modalTheme: { content: { backgroundColor: 'white' } } };
-    const dummyParent = 'dummyParentClassname';
+    const parentClass = 'dummyParentClassname';
     const themeStrategyResult = driver.runStrategy({
       palette: wixPalettes.site1,
-      parentClass: dummyParent,
+      parentClass,
       cssOverride,
     });
     const { rawCss } = themeStrategyResult;
     expect(rawCss).toBeDefined();
     rawCss?.split('\n').forEach(line => {
-      if (line.startsWith('.')) expect(line.startsWith(`.${dummyParent} `)).toBeTruthy();
+      if (line.startsWith('.')) expect(line.startsWith(`.${parentClass} `)).toBeTruthy();
     });
   });
 });

--- a/packages/ricos-common/web/src/themeStrategy/themeStrategy.ts
+++ b/packages/ricos-common/web/src/themeStrategy/themeStrategy.ts
@@ -3,6 +3,7 @@ import jss, { SheetsRegistry, Classes } from 'jss';
 import preset from 'jss-preset-default';
 import { defaultTheme } from './defaults';
 import { PalettePreset, Palette, ThemeGeneratorFunction, RicosCssOverride } from './themeTypes';
+import { RicosTheme } from '../RicosTypes';
 
 jss.setup(preset());
 
@@ -15,8 +16,10 @@ interface ThemeState {
 interface ThemeStrategyArgs {
   isViewer: boolean;
   themeGeneratorFunctions?: ThemeGeneratorFunction[];
+  theme?: RicosTheme;
   palette?: Palette | PalettePreset;
   cssOverride?: RicosCssOverride;
+  parentClass?: string;
 }
 
 interface ThemeStrategyResult {
@@ -26,8 +29,15 @@ interface ThemeStrategyResult {
 
 export type ThemeStrategyFunction = (args: ThemeStrategyArgs) => ThemeStrategyResult;
 
+const addParentClass = (rawCss: string, parentClass: string): string =>
+  rawCss
+    .split('\n')
+    .map(line => (line.startsWith('.') ? `.${parentClass} ${line}` : line))
+    .join('\n');
+
 function themeStrategy(themeState: ThemeState, args: ThemeStrategyArgs): ThemeStrategyResult {
-  const { isViewer, themeGeneratorFunctions, palette, cssOverride } = args;
+  const { isViewer, themeGeneratorFunctions, theme = {}, cssOverride } = args;
+  const { palette, parentClass } = theme;
   const sheets = new SheetsRegistry();
   if (themeState.prevPalette !== palette || !themeState.rawCss) {
     if (palette) {
@@ -35,16 +45,21 @@ function themeStrategy(themeState: ThemeState, args: ThemeStrategyArgs): ThemeSt
       const themeGenerator = new ThemeGenerator(isViewer, palette, themeGeneratorFunctions);
       const sheet = jss.createStyleSheet(themeGenerator.getStylesObject());
       sheets.add(sheet);
+      const rawCss = sheets.toString();
       themeState.paletteClasses = sheet.classes;
-      themeState.rawCss = sheets.toString();
+      themeState.rawCss = parentClass ? addParentClass(rawCss, parentClass) : rawCss;
     } else {
       themeState.paletteClasses = {};
       themeState.rawCss = '';
     }
   }
-  const theme: RicosCssOverride = { ...defaultTheme, ...themeState.paletteClasses, ...cssOverride };
+  const cssTheme: RicosCssOverride = {
+    ...defaultTheme,
+    ...themeState.paletteClasses,
+    ...cssOverride,
+  };
   return {
-    theme,
+    theme: cssTheme,
     rawCss: themeState.rawCss,
   };
 }

--- a/packages/ricos-common/web/src/themeStrategy/themeStrategy.ts
+++ b/packages/ricos-common/web/src/themeStrategy/themeStrategy.ts
@@ -17,9 +17,7 @@ interface ThemeStrategyArgs {
   isViewer: boolean;
   themeGeneratorFunctions?: ThemeGeneratorFunction[];
   theme?: RicosTheme;
-  palette?: Palette | PalettePreset;
   cssOverride?: RicosCssOverride;
-  parentClass?: string;
 }
 
 interface ThemeStrategyResult {


### PR DESCRIPTION
Theme fix for multiple instances of RicosEditor / RicosViewer
New field for `theme` prop: `parentClass`