### PR TITLE
[file] fix(componentData): tempData is used to indicate upload in progress

### DIFF
--- a/packages/plugin-file-upload/web/src/file-upload-component.jsx
+++ b/packages/plugin-file-upload/web/src/file-upload-component.jsx
@@ -61,7 +61,7 @@ class FileUploadComponent extends PureComponent {
       const name = file.name;
       const fileNameParts = name.split('.');
       const type = fileNameParts[fileNameParts.length - 1];
-      this.updateComponentData({ name, type, size: file.size });
+      this.updateComponentData({ name, type, size: file.size, tempData: true });
       this.setState({ isLoading: true, error: null });
       onFileSelected(file, ({ data, error }) => this.handleFilesAdded({ data, error }));
     } else {
@@ -74,7 +74,7 @@ class FileUploadComponent extends PureComponent {
       this.resetLoadingState(error);
       return;
     }
-    this.updateComponentData(data);
+    this.updateComponentData({ ...data, tempData: undefined });
     this.resetLoadingState();
   };
 

--- a/packages/ricos-editor/web/src/utils/hasActiveUploads.spec.ts
+++ b/packages/ricos-editor/web/src/utils/hasActiveUploads.spec.ts
@@ -88,12 +88,15 @@ describe('hasActiveUploads service', () => {
   });
 
   describe('file plugin', () => {
-    it('should return true if file name is missing', () => {
-      const contentState = createContentState(FILE_UPLOAD_TYPE, {});
+    it('should return true if file exists and tempData = true', () => {
+      const contentState = createContentState(FILE_UPLOAD_TYPE, {
+        name: 'myfile.txt',
+        tempData: true,
+      });
       expect(hasActiveUploads(contentState)).toBe(true);
     });
 
-    it('should return false if file name exists', () => {
+    it('should return false if file exists and tempData !== true', () => {
       const contentState = createContentState(FILE_UPLOAD_TYPE, { name: 'myfile.txt' });
       expect(hasActiveUploads(contentState)).toBe(false);
     });

--- a/packages/ricos-editor/web/src/utils/hasActiveUploads.spec.ts
+++ b/packages/ricos-editor/web/src/utils/hasActiveUploads.spec.ts
@@ -65,9 +65,9 @@ describe('hasActiveUploads service', () => {
   });
 
   describe('video plugin', () => {
-    it('should return true if custom video is missing', () => {
+    it('should return false if custom video is missing', () => {
       const contentState = createContentState(VIDEO_TYPE, {});
-      expect(hasActiveUploads(contentState)).toBe(true);
+      expect(hasActiveUploads(contentState)).toBe(false);
     });
 
     it('should return true if custom video is present and tempData = true', () => {

--- a/packages/ricos-editor/web/src/utils/hasActiveUploads.ts
+++ b/packages/ricos-editor/web/src/utils/hasActiveUploads.ts
@@ -6,10 +6,10 @@ const isUploadingImage = (entity: EntityInstance) =>
   entity.getType() === IMAGE_TYPE && !entity.getData().src;
 
 const isUploadingVideo = (entity: EntityInstance) =>
-  entity.getType() === VIDEO_TYPE && entity.getData().tempData !== false;
+  entity.getType() === VIDEO_TYPE && entity.getData().tempData === true;
 
 const isUploadingFile = (entity: EntityInstance) =>
-  entity.getType() === FILE_UPLOAD_TYPE && !entity.getData().name;
+  entity.getType() === FILE_UPLOAD_TYPE && entity.getData().tempData === true;
 
 const isUploadingGallery = (entity: EntityInstance) => {
   const items = entity.getData().items as { url: string }[];


### PR DESCRIPTION
Recent changes to file plugin made the `name` property not relevant anymore for indicating that an upload is in progress. Now `tempData` is used for this purpose instead, following video plugin's pattern.