### PR TITLE
handleBeforeInput params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   - [#1452](https://github.com/wix-incubator/rich-content/pull/1452) debugging info reported to console if `ricosDebug=true` query param found
 ### :bug: Bug Fix
 - `editor`
-  - RichContentEditor: draft `handleBeforeInput` params passed to `props.handleBeforeInput`
+  - [#1454](https://github.com/wix-incubator/rich-content/pull/1454) RichContentEditor: draft `handleBeforeInput` params passed to `props.handleBeforeInput`
 - `editor-common`
   - [#1448](https://github.com/wix-incubator/rich-content/pull/1448) colorPicker reset to default and + button (regression from 7.16.3, PR#1428)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@
     Click to see more.
   </summary>
   
+### :rocket: New Feature
+- `common`
+  - [#1452](https://github.com/wix-incubator/rich-content/pull/1452) debugging info reported to console if `ricosDebug=true` query param found
 ### :bug: Bug Fix
+- `editor`
+  - RichContentEditor: draft `handleBeforeInput` params passed to `props.handleBeforeInput`
 - `editor-common`
   - [#1448](https://github.com/wix-incubator/rich-content/pull/1448) colorPicker reset to default and + button (regression from 7.16.3, PR#1428)
 
@@ -26,8 +31,6 @@
 
 ## 7.16.4 (Aug 13, 2020) 
 ### :rocket: New Feature
-- `common`
-  - [#1452](https://github.com/wix-incubator/rich-content/pull/1452) debugging info reported to console if `ricosDebug=true` query param found
 - `editor`
   - [#1370](https://github.com/wix-incubator/rich-content/pull/1370) external toolbar API updated
 - `ricos-editor`

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
@@ -435,9 +435,8 @@ class RichContentEditor extends Component {
     return modals;
   };
 
-  handleBeforeInput = () => {
-    const { handleBeforeInput } = this.props;
-    handleBeforeInput?.();
+  handleBeforeInput = (chars, editorState, timestamp) => {
+    this.props.handleBeforeInput?.(chars, editorState, timestamp);
 
     const blockType = getBlockType(this.state.editorState);
     if (blockType === 'atomic') {


### PR DESCRIPTION
### :bug: Bug Fix
- `editor`
  - RichContentEditor: draft `handleBeforeInput` params passed to `props.handleBeforeInput`
