### PR TITLE
[preview] fix(readMore): display edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `preview`
   - [#1482](https://github.com/wix-incubator/rich-content/pull/1482) ReadMore click expands the full content
   - [#1485](https://github.com/wix-incubator/rich-content/pull/1485) fix readmore visibility when there are multiple text fragments
+  - [#1492](https://github.com/wix-incubator/rich-content/pull/1492) edge case of 1 image + {x} plugins prevented display of "read more" label
 - `plugins`
   - [#1481](https://github.com/wix-incubator/rich-content/pull/1481) line-spacing & text-color: external toolbar dropdown styles fixed
 - `ricos-editor`

--- a/packages/preview/web/src/ContentStateAnalyzer/ContentStateMetadata.js
+++ b/packages/preview/web/src/ContentStateAnalyzer/ContentStateMetadata.js
@@ -105,6 +105,8 @@ const extractMedia = ({ entityMap }) =>
 
 const isGalleryItem = type => ['image', 'video', 'giphy'].includes(type);
 
+const countEntities = ({ entityMap }) => Object.values(entityMap).length;
+
 const getContentStateMetadata = raw => {
   const metadata = {
     allText: extractTextBlockArray(raw, type => type !== 'atomic'),
@@ -135,6 +137,7 @@ const getContentStateMetadata = raw => {
   metadata.files = media.filter(({ type }) => type === 'file');
   metadata.maps = media.filter(({ type }) => type === 'map');
   metadata.links = media.filter(({ type }) => type === 'link');
+  metadata.nonMediaPluginsCount = countEntities(raw) - metadata.galleryItems.length;
 
   return metadata;
 };

--- a/packages/preview/web/statics/styles/read-more.scss
+++ b/packages/preview/web/statics/styles/read-more.scss
@@ -13,10 +13,11 @@
   color: #000;
 }
 
+@import '~wix-rich-content-common/dist/statics/styles/palette';
 .readMore_label {
   font-weight: normal;
   text-decoration: none;
-  color: #0261ff;
+  color: $accent-color;
   font-size: 14px;
   &:hover {
     text-decoration: underline;

--- a/packages/preview/web/statics/styles/see-full-post.scss
+++ b/packages/preview/web/statics/styles/see-full-post.scss
@@ -1,4 +1,5 @@
 @import '~wix-rich-content-common/dist/statics/styles/palette';
+@import './read-more.scss';
 .seeFullPost_container {
   position: relative;
 }
@@ -11,6 +12,6 @@
 }
 
 .seeFullPost_label {
-  margin-top: 5px;
-  color: $accent-color;
+  @extend .readMore_label;
+  margin-top: 3px;
 }


### PR DESCRIPTION
Fixed 2 issues:
- Edge case of 1 image + x plugins -> prevented displaying readMore (screenshot attached)
- readMore style - font style matching for both top & bottom scenarios

|Before|After|
|--|--|
|![Screen Shot 2020-08-30 at 12 41 27](https://user-images.githubusercontent.com/22775305/91656081-63f66780-eabe-11ea-8a79-bebd38810810.png)|![Screen Shot 2020-08-30 at 12 41 39](https://user-images.githubusercontent.com/22775305/91656102-9f913180-eabe-11ea-9b99-e9e3444b6d9c.png)|

