### PR TITLE
[workflows] improve(actions): ignores

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,10 @@ on:
       - '**'
     branches:
       - '**'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'bundle-analyzer/**'
 jobs:
   deploy-examples:
     runs-on: ubuntu-18.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,11 @@ on:
       - '**'
     branches-ignore:
       - 'release*'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'bundle-analyzer/**'
 env:
   captureVideos: 'true'
   captureImages: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   - [#1515](https://github.com/wix-incubator/rich-content/pull/1515) bundle size improved by removing unused JSS plugins
 - `general`
   - [#1525](https://github.com/wix-incubator/rich-content/pull/1525) typed theme functions for all plugins
+- `workflows`
+  - [#1529](https://github.com/wix-incubator/rich-content/pull/1529) ignore test runs when irrelevant
 
 </details>
 


### PR DESCRIPTION
Added [paths & paths-ignore](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-paths) for more efficient CI process.

Example: no need to run tests if only `CHANGELOG.md` was changed.

@shaulgo @mharsat @lxgreen What do you think?