### PR TITLE
[ricos-editor] fix(theme): inlineToolbarButtons new design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
     Click to see more.
   </summary>
 
+### :bug: Bug Fix
+- `ricos-editor`
+  - [#1542](https://github.com/wix-incubator/rich-content/pull/1542) fixed appearance of inlineToolbarButtons to the new design
+
 ### 🏠 Internal
 - `exampleApp`
   - [#1541](https://github.com/wix-incubator/rich-content/pull/1541) file upload native\media manager toggle in gear icon

--- a/packages/editor-common/web/src/Components/InlineToolbarButton.jsx
+++ b/packages/editor-common/web/src/Components/InlineToolbarButton.jsx
@@ -134,7 +134,6 @@ class InlineToolbarButton extends Component {
       </div>
     );
     /* eslint-enable jsx-a11y/no-static-element-interactions */
-
     return <ToolbarButton theme={theme} tooltipText={tooltipText} button={codeBlockButton} />;
   }
 }

--- a/packages/editor-common/web/statics/styles/inline-toolbar-button.scss
+++ b/packages/editor-common/web/statics/styles/inline-toolbar-button.scss
@@ -72,5 +72,3 @@
   transform: rotate(180deg);
   top: -2px;
 }
-
-

--- a/packages/ricos-theme/web/src/themes/editor-common.ts
+++ b/packages/ricos-theme/web/src/themes/editor-common.ts
@@ -171,11 +171,17 @@ export default function editorCommon(colors: PaletteColors) {
       },
     },
     inlineToolbarButton_wrapper: {
-      '& $inlineToolbarButton_icon:hover': {
+      '&:hover button': {
+        backgroundColor: hexToRgbA(actionColor, 0.1),
+      },
+      '&:hover $inlineToolbarButton_icon': {
         color: actionColor,
       },
-      '& $inlineToolbarButton_icon:hover svg': {
+      '&:hover $inlineToolbarButton_icon svg': {
         fill: actionColor,
+      },
+      '&$inlineToolbarButton_active button': {
+        backgroundColor: hexToRgbA(actionColor, 0.05),
       },
     },
 

--- a/packages/ricos-theme/web/src/themes/editor-common.ts
+++ b/packages/ricos-theme/web/src/themes/editor-common.ts
@@ -174,16 +174,30 @@ export default function editorCommon(colors: PaletteColors) {
       '&:hover button': {
         backgroundColor: hexToRgbA(actionColor, 0.1),
       },
-      '&:hover $inlineToolbarButton_icon': {
-        color: actionColor,
-      },
-      '&:hover $inlineToolbarButton_icon svg': {
-        fill: actionColor,
-      },
+      '&:hover $inlineToolbarButton_icon': toolbarButtonStyle,
+      '&:hover $inlineToolbarButton_icon svg': toolbarButtonStyle,
+      '&:hover $inlineToolbarDropdownButton_icon svg': toolbarButtonStyle,
       '&$inlineToolbarButton_active button': {
         backgroundColor: hexToRgbA(actionColor, 0.05),
       },
     },
+
+    //inline-toolbar-dropdown-button.scss
+    inlineToolbarDropdown_wrapper: {
+      '&:hover $inlineToolbarDropdownButton_active svg': toolbarButtonStyle,
+      '&:hover>div:not($inlineToolbarDropdown_options) button': {
+        backgroundColor: hexToRgbA(actionColor, 0.1),
+      },
+      '&:hover>div:not($inlineToolbarDropdown_options) button svg': toolbarButtonStyle,
+      '&>div:not($inlineToolbarDropdown_options) $inlineToolbarDropdownButton_active': {
+        backgroundColor: hexToRgbA(actionColor, 0.1),
+      },
+    },
+    inlineToolbarDropdownButton_active: {
+      '& svg': toolbarButtonStyle,
+    },
+    inlineToolbarDropdownButton_icon: {},
+    inlineToolbarDropdown_options: {},
 
     //plugin-toolbar-button.scss
     pluginToolbarButton_disabled: {},


### PR DESCRIPTION
Fixed inline toolbar styles - for Ricos only

|Before|After|
|------|-----|
|![before](https://user-images.githubusercontent.com/22775305/92747030-74df8c80-f38c-11ea-9db8-9afbd1ab969a.gif)|![after](https://user-images.githubusercontent.com/22775305/92747043-79a44080-f38c-11ea-9e3e-64f20bedcb50.gif)|



