### PR TITLE
[docs] fix(docusaurus-plugin-sass): update version to patch

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "@docusaurus/core": "^2.0.0-alpha.55",
     "@docusaurus/preset-classic": "^2.0.0-alpha.55",
     "classnames": "^2.2.6",
-    "docusaurus-plugin-sass": "^0.1.8",
+    "docusaurus-plugin-sass": "git+https://github.com/slorber/docusaurus-plugin-sass.git#patch-1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "ricos-editor": "^7.16.15",


### PR DESCRIPTION
Fixes sass-loader issue
```
ValidationError: Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'id'. These properties are valid:
   object { implementation?, sassOptions?, prependData?, sourceMap?, webpackImporter? }
```

Uses patch version suggested here, should update version once PR is merged
https://github.com/rlamana/docusaurus-plugin-sass/pull/5