### PR TITLE
[preview] fix readMore cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 ### :bug: Bug Fix
 - `viewer`
   - [#1557](https://github.com/wix-incubator/rich-content/pull/1557) fix viewer justify css for safari and firefox
+- `preview`
+  - [#1562](https://github.com/wix-incubator/rich-content/pull/1562) readMore display edgecase fix + gallery responsiveness
 
 ### 🏠 Internal
 - `e2e`

--- a/packages/preview/web/src/Components/default-transformation.ts
+++ b/packages/preview/web/src/Components/default-transformation.ts
@@ -32,8 +32,14 @@ const galleryStyle = {
 
 const showReadMore = ({ media: { singleMediaItems } }) => singleMediaItems.length < 2;
 
-const showFullPost = ({ media: { singleMediaItems }, textFragments, nonMediaPluginsCount }) =>
-  (textFragments.length > 1 && singleMediaItems.length === 0) || nonMediaPluginsCount > 0;
+const showFullPost = ({
+  media: { singleMediaItems },
+  textFragments,
+  nonMediaPluginsCount,
+  collapsablePluginsCount,
+}) =>
+  (textFragments.length > 1 && singleMediaItems.length === 0) ||
+  (nonMediaPluginsCount > 0 && collapsablePluginsCount > 0);
 
 export const defaultTransformation = new ContentStateTransformation({
   _if: metadata => metadata.allText.length > 0,
@@ -41,12 +47,13 @@ export const defaultTransformation = new ContentStateTransformation({
     const {
       textFragments,
       nonMediaPluginsCount,
+      collapsablePluginsCount,
       media: { singleMediaItems, galleryItems },
     } = metadata;
     const showToggle =
       showReadMore(metadata) &&
       !showFullPost(metadata) &&
-      nonMediaPluginsCount === 0 &&
+      collapsablePluginsCount === 0 &&
       textFragments.length === 1;
     const previewToDisplay = preview.plain(textFragments[0]).readMore({ lines: 3, showToggle });
     if (
@@ -76,6 +83,7 @@ export const defaultTransformation = new ContentStateTransformation({
     _if: metadata =>
       metadata.media.singleMediaItems.length > 1 && metadata.media.singleMediaItems.length <= 4,
     _then: ({ media: { galleryItems, singleMediaItems, totalCount } }, preview) => {
+      const numberOfImagesPerRow = singleMediaItems.length % 2 === 0 ? 2 : 3;
       const gallery = preview
         .gallery({
           mediaInfo: singleMediaItems.slice(0, 4),
@@ -83,7 +91,7 @@ export const defaultTransformation = new ContentStateTransformation({
             size: 'small',
           },
           overrides: {
-            styles: galleryStyle,
+            styles: { ...galleryStyle, numberOfImagesPerRow },
           },
         })
         .seeFullPost();

--- a/packages/preview/web/src/ContentStateAnalyzer/ContentStateMetadata.ts
+++ b/packages/preview/web/src/ContentStateAnalyzer/ContentStateMetadata.ts
@@ -158,6 +158,11 @@ const getContentStateMetadata = (raw: RicosContent) => {
     {} as ExposedGroupBlocks
   );
 
+  const nonMediaPluginsCount = countEntities(raw) - media.totalCount;
+  const nonSeparatorPlugins = mediaEntities.filter(({ type }) =>
+    ['link', 'hashtag', 'mention'].includes(type)
+  );
+
   const metadata: PreviewMetadata = {
     allText: extractTextBlockArray(raw, (type: string) => type !== 'atomic'),
     textFragments: createTextFragments(raw),
@@ -167,7 +172,8 @@ const getContentStateMetadata = (raw: RicosContent) => {
     files: mediaEntities.filter(({ type }) => type === 'file'),
     maps: mediaEntities.filter(({ type }) => type === 'map'),
     links: mediaEntities.filter(({ type }) => type === 'link'),
-    nonMediaPluginsCount: countEntities(raw) - media.totalCount,
+    nonMediaPluginsCount,
+    collapsablePluginsCount: nonMediaPluginsCount - nonSeparatorPlugins.length,
     ...blocks,
     ...groupedBlocks,
   };

--- a/packages/preview/web/src/types.ts
+++ b/packages/preview/web/src/types.ts
@@ -43,4 +43,5 @@ export interface PreviewMetadata extends ExposedBlocks, ExposedGroupBlocks {
   maps: unknown[];
   links: unknown[];
   nonMediaPluginsCount: number;
+  collapsablePluginsCount: number;
 }


### PR DESCRIPTION
Fixes:
- decorative plugins caused unnecessary readMore display (links etc)
- collapsed gallery is responsive to screen (2-4 images). for +4 images, 2x2 grid will remain

****

|Before|After|
|------|-----|
|![Screen Shot 2020-09-20 at 22 01 32](https://user-images.githubusercontent.com/22775305/93719743-2f417180-fb8d-11ea-99aa-5ce19cd91293.png)|![Screen Shot 2020-09-20 at 22 01 41](https://user-images.githubusercontent.com/22775305/93719746-323c6200-fb8d-11ea-9561-94bffcebb42d.png)|

|Before|After|
|------|-----|
|![Screen Shot 2020-09-20 at 22 00 33](https://user-images.githubusercontent.com/22775305/93719758-46805f00-fb8d-11ea-8c3d-f23f97916d38.png)|![Screen Shot 2020-09-20 at 22 00 44](https://user-images.githubusercontent.com/22775305/93719777-6c0d6880-fb8d-11ea-9db6-a1ceb291d6d4.png)|


