### PR TITLE
[editor] fix: closePluginMenu is not a function in mobile

### DIFF
--- a/packages/editor/web/src/RichContentEditor/Toolbars/SideToolbar/PluginMenuPluginsSection.js
+++ b/packages/editor/web/src/RichContentEditor/Toolbars/SideToolbar/PluginMenuPluginsSection.js
@@ -58,7 +58,7 @@ const PluginMenuPluginsSection = ({
                 toolbarName={toolbarName}
                 hidePopup={hidePopup}
                 theme={theme}
-                closePluginMenu={!isMobile && hidePopup}
+                closePluginMenu={!isMobile ? hidePopup : undefined}
               />
             </div>
           ))}


### PR DESCRIPTION
pass `undefined` to closePluginMenu in mobile, instead of passing boolean value which lead throwing an error: closePluginMenu is not a function.