### PR TITLE
[ricos-editor] fix: plugins with modal in inline toolbar didn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 ### :bug: Bug Fix
 - `editor-common`
   - [#1650](https://github.com/wix-incubator/rich-content/pull/1650) fix modals text color issue on dark theme
+- `ricos-editor`
+  - [#1669](https://github.com/wix-incubator/rich-content/pull/1669) fix inline toolbar plugins with modal in inner-rce
 
 ### :book: Documentation
 - `text-color`

--- a/packages/ricos-editor/web/src/RicosEditor.tsx
+++ b/packages/ricos-editor/web/src/RicosEditor.tsx
@@ -20,6 +20,7 @@ export class RicosEditor extends Component<RicosEditorProps, State> {
   editor: RichContentEditor;
   dataInstance: EditorDataInstance;
   isBusy = false;
+  currentEditorRef: ElementType;
 
   constructor(props: RicosEditorProps) {
     super(props);
@@ -41,7 +42,8 @@ export class RicosEditor extends Component<RicosEditorProps, State> {
   }
 
   setStaticToolbar = ref => {
-    if (ref) {
+    if (ref && ref !== this.currentEditorRef) {
+      this.currentEditorRef = ref;
       const { MobileToolbar, TextToolbar } = ref.getToolbars();
       this.setState({ StaticToolbar: MobileToolbar || TextToolbar });
     }


### PR DESCRIPTION
Currently, when using inner-rce with plugins with modals from the inline toolbar, the plugins don't work.
This is due to race condition of setState of `RicosEditor` from `setStaticToolbar` function.
This PR avoids setState when not needed, it first checks that ref has changed and then update the `StaticToolbar` which fixes the bug.