### PR TITLE
[accordion] fix: add stopPropagation, to prevent draft from throwing getIn error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 ### :bug: Bug Fix
 - `plugin-link`
   - [#1666](https://github.com/wix-incubator/rich-content/pull/1666) anchor - scroll location on sites with fixed headers
+- `accordion`
+  - [#1687](https://github.com/wix-incubator/rich-content/pull/1687) fix "getIn" error (draftjs bug)
 
 ### :book: Documentation
 - `emoji`

--- a/packages/plugin-accordion/web/src/accordion-component.jsx
+++ b/packages/plugin-accordion/web/src/accordion-component.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from 'react';
 import PropTypes from 'prop-types';
 import AccordionPairs from './components/AccordionPairs';
@@ -145,6 +147,8 @@ class AccordionComponent extends React.Component {
     );
   };
 
+  onFocus = e => e.stopPropagation();
+
   render() {
     const { blockProps, theme, isMobile } = this.props;
     const pairs = this.getDataManager().getPairs();
@@ -153,7 +157,12 @@ class AccordionComponent extends React.Component {
     const direction = this.getDataManager().getDirection();
 
     return (
-      <div className={this.styles[direction]} data-hook="accordionComponent">
+      <div
+        className={this.styles[direction]}
+        onFocus={this.onFocus}
+        tabIndex="0"
+        data-hook="accordionComponent"
+      >
         <DragDropContext onDragEnd={this.onDragEnd}>
           <Droppable droppableId="droppable">
             {provided => (


### PR DESCRIPTION
Added `onFocus` to AccordionComponent to fix a problem of draft, that throws "getIn" error.