### PR TITLE
[webpack] fix: merge is not a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   - [#1643](https://github.com/wix-incubator/rich-content/pull/1643) converted to TS and moved from scripts to packages folder
 - `general`
   - [#1643](https://github.com/wix-incubator/rich-content/pull/1643) converted RichContentEditor, RichContentViewer and many plugin and utility files to TS
+- `general`
+  - [#1695](https://github.com/wix-incubator/rich-content/pull/1695) update webpack-merge "merge" function consumption
 
 </details>
 <hr/>

--- a/examples/main/config/webpack.dev.js
+++ b/examples/main/config/webpack.dev.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 const path = require('path');
-const merge = require('webpack-merge');
+const merge = require('webpack-merge').merge;
 const { HotModuleReplacementPlugin } = require('webpack');
 
 const PATHS = {


### PR DESCRIPTION
This PR fixes the TypeError: merge is not a function in webpack.