### PR TITLE
[viewer] move justify fix for safari/firefox to span child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
     Click to see more.
   </summary>
 
+### :bug: Bug Fix
+- `viewer`
+  - [#1731](https://github.com/wix-incubator/rich-content/pull/1731) fix justify in safari/firefox (adjust previous fix for the new dom structure)
 
 </details>
 <hr/>

--- a/e2e/tests/__snapshots__/text.e2e.js.snap
+++ b/e2e/tests/__snapshots__/text.e2e.js.snap
@@ -1995,7 +1995,7 @@ exports[`textFirefox > Enter click and space should keep the line when justified
       "entityRanges": [],
       "inlineStyleRanges": [],
       "key": 0,
-      "text": "   Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster.",
+      "text": "   Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster. Iterative approaches to corporate strategy foster",
       "type": "unstyled"
     },
     {
@@ -2017,7 +2017,7 @@ exports[`textFirefox > Enter click and space should keep the line when justified
       "entityRanges": [],
       "inlineStyleRanges": [],
       "key": 2,
-      "text": "next line ",
+      "text": "next line.",
       "type": "unstyled"
     }
   ],

--- a/e2e/tests/text.e2e.js
+++ b/e2e/tests/text.e2e.js
@@ -273,11 +273,11 @@ describe('textFirefox', () => {
   it('Enter click and space should keep the line when justified', function() {
     cy.loadRicosEditorAndViewer()
       .enterParagraphs([
-        '   Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster. ',
+        '   Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster. Iterative approaches to corporate strategy foster.',
       ])
-      .setEditorSelection(0, 134)
+      .setEditorSelection(0, 184)
       .setAlignment(INLINE_TOOLBAR_BUTTONS.TEXT_ALIGN_JUSTIFY)
-      .setEditorSelection(134, 0)
+      .setEditorSelection(184, 0)
       .type('{enter}')
       .type('{enter}')
       .enterParagraphs([' '])

--- a/packages/viewer/web/src/utils/convertContentState.tsx
+++ b/packages/viewer/web/src/utils/convertContentState.tsx
@@ -117,7 +117,6 @@ const getBlocks = (mergedStyles, textDirection, context, addAnchorsPrefix) => {
                 alignment,
                 mergedStyles[style]
               ),
-              hasJustifyText && styles.hasJustifyText,
               depthClassName(depth),
               directionBlockClassName,
               isPaywallSeo(context.seoMode) &&
@@ -126,7 +125,15 @@ const getBlocks = (mergedStyles, textDirection, context, addAnchorsPrefix) => {
             style={blockDataToStyle(blockProps.data[i])}
             key={blockProps.keys[i]}
           >
-            <span className={classNames(styles.child, directionTextClassName)}>{_child}</span>
+            <span
+              className={classNames(
+                styles.child,
+                directionTextClassName,
+                hasJustifyText && styles.hasJustifyText
+              )}
+            >
+              {_child}
+            </span>
           </ChildTag>
         );
 

--- a/packages/viewer/web/statics/rich-content-viewer.scss
+++ b/packages/viewer/web/statics/rich-content-viewer.scss
@@ -123,7 +123,6 @@
 
 .child {
   display: block;
-  white-space: pre-wrap;
 }
 
 .unorderedList.center{


### PR DESCRIPTION
Bug fix for justify in Safari/Firefox has moved to `span` element in `convertContentState`.