### PR TITLE
[editor] fix: switching focus between inner-rce's in composition mode (Draft-js & Android with Google keyboard issues)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 ### :bug: Bug Fix
 - `gallery`
   - [#1776](https://github.com/wix-incubator/rich-content/pull/1776) fix gallery flickering
+- `editor`
+  - [#1784](https://github.com/wix-incubator/rich-content/pull/1784) fix switching focus between inner-rce's in composition mode (Draft-js & Android with Google Keyboard issues)
 
 ### :book: Documentation
 - [##1782](https://github.com/wix-incubator/rich-content/pull/#1782) legacy docs cleanup

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -23,7 +23,6 @@ import {
   getBlockType,
   COMMANDS,
   MODIFIERS,
-  SelectionState,
 } from 'wix-rich-content-editor-common';
 import { convertFromRaw, convertToRaw } from '../../lib/editorStateConversion';
 import { EditorProps as DraftEditorProps } from 'draft-js';

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -830,17 +830,9 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
   };
 
   disableFocusInSelection = (editorState: EditorState) => {
-    const selection = editorState.getSelection().toJS();
-    const newSelection = new SelectionState({
-      anchorKey: selection.anchorKey,
-      anchorOffset: selection.anchorOffset,
-      focusKey: selection.focusKey,
-      focusOffset: selection.focusOffset,
-      isBackward: selection.isBackward,
-      hasFocus: false,
-    });
+    const selection = editorState.getSelection().merge({ hasFocus: false });
     const newEditorState = EditorState.set(editorState, {
-      selection: newSelection,
+      selection,
     });
     this.updateEditorState(newEditorState);
   };

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -23,6 +23,7 @@ import {
   getBlockType,
   COMMANDS,
   MODIFIERS,
+  SelectionState,
 } from 'wix-rich-content-editor-common';
 import { convertFromRaw, convertToRaw } from '../../lib/editorStateConversion';
 import { EditorProps as DraftEditorProps } from 'draft-js';
@@ -828,12 +829,32 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
     }
   };
 
+  disableFocusInSelection = (editorState: EditorState) => {
+    const selection = editorState.getSelection().toJS();
+    const newSelection = new SelectionState({
+      anchorKey: selection.anchorKey,
+      anchorOffset: selection.anchorOffset,
+      focusKey: selection.focusKey,
+      focusOffset: selection.focusOffset,
+      isBackward: selection.isBackward,
+      hasFocus: false,
+    });
+    const newEditorState = EditorState.set(editorState, {
+      selection: newSelection,
+    });
+    this.updateEditorState(newEditorState);
+  };
+
   onBlur = e => {
+    const { editorState } = this.state;
     const { isInnerRCE } = this.props;
     if (!isInnerRCE && !this.inPluginEditingMode) {
       if (e.relatedTarget && e.relatedTarget.closest('[data-id=inner-rce]')) {
         this.setInPluginEditingMode(true);
       }
+    }
+    if (isInnerRCE && editorState.isInCompositionMode()) {
+      this.disableFocusInSelection(editorState);
     }
   };
 


### PR DESCRIPTION
In Mobile, using **Android** device & **Google** keyboard, when moving between Inner-rce's, the focus bumps to the previous editor that was focused, there are two `onFocus` actions that are been triggered because of Draft-js & Android event handlers bugs.
In order to fix it, when `onBlur` triggers (of the first Editor that is been blurred), setting the SelectionState to have `hasFocus` = false, disables the second unwanted `onFocus` actions from triggering.
This change will only happen when blurring from Inner-RCE and EditorState is in CompositionMode.