### PR TITLE
[editor, editor-common] fix: add types annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@
 
 ### :bug: Bug Fix
 - `viewer`
-  - [##1780](https://github.com/wix-incubator/rich-content/pull/#1780) preview interaction block wrapping logic refactored
+  - [#1780](https://github.com/wix-incubator/rich-content/pull/1780) preview interaction block wrapping logic refactored
+
+### :house: Internal
+- `editor`
+  - [#1791](https://github.com/wix-incubator/rich-content/pull/1791) add missing types in `createPlugins`
+- `editor-common`
+  - [#1791](https://github.com/wix-incubator/rich-content/pull/1791) add missing types in `getModalStyles`
 
 </details>
 <hr/>

--- a/packages/editor-common/web/src/Utils/getModalStyles.ts
+++ b/packages/editor-common/web/src/Utils/getModalStyles.ts
@@ -188,7 +188,7 @@ export const getBottomToolbarModalStyles = (
     isMobile?: boolean;
   },
   toolbarName?: string
-) => {
+): ModalStyles => {
   const modalStyles = getModalStyles({
     customStyles,
     fullScreen,

--- a/packages/editor/web/src/RichContentEditor/createPlugins.ts
+++ b/packages/editor/web/src/RichContentEditor/createPlugins.ts
@@ -42,7 +42,13 @@ const createPlugins = ({
   plugins?: CreatePluginFunction[];
   context: EditorContextType;
   commonPubsub: Pubsub;
-}) => {
+}): {
+  pluginInstances: unknown[];
+  pluginButtons: PluginButton[];
+  pluginTextButtons: TextButtonMapping[];
+  pluginStyleFns: EditorProps['customStyleFn'][];
+  externalizedButtonProps: ToolbarButtonProps[];
+} => {
   const focusPlugin = createFocusPlugin();
   const resizePlugin = createResizeDecoration({
     horizontal: 'absolute',

--- a/packages/editor/web/src/RichContentEditor/createPlugins.ts
+++ b/packages/editor/web/src/RichContentEditor/createPlugins.ts
@@ -1,11 +1,11 @@
-import { composeDecorators } from 'draft-js-plugins-editor';
+import { EditorPlugin, composeDecorators } from 'draft-js-plugins-editor';
 import createFocusPlugin from 'forked-draft-js-focus-plugin';
 import createResizeDecoration from './Decorators/Resize';
 import createBlockDndPlugin from 'draft-js-drag-n-drop-plugin';
 import createHandleDrop from './handleDrop';
 import createExternalToolbarPlugin from './externalToolbarPlugin';
 import createListPlugin from 'draft-js-list-plugin';
-import { EditorProps } from 'draft-js';
+import { EditorProps, DraftDecorator } from 'draft-js';
 import {
   CreatePluginFunction,
   CreatePluginConfig,
@@ -43,7 +43,10 @@ const createPlugins = ({
   context: EditorContextType;
   commonPubsub: Pubsub;
 }): {
-  pluginInstances: unknown[];
+  pluginInstances: (
+    | (EditorPlugin & { decorator?: DraftDecorator })
+    | ReturnType<CreatePluginFunction>
+  )[];
   pluginButtons: PluginButton[];
   pluginTextButtons: TextButtonMapping[];
   pluginStyleFns: EditorProps['customStyleFn'][];


### PR DESCRIPTION
Add missing types in `createPlugins` and `getModalStyles`.